### PR TITLE
Make sure persistence manager works properly with multiple services.

### DIFF
--- a/bundles/org.connectorio.addons.binding.can/src/main/java/org/connectorio/addons/binding/can/internal/discovery/DBusCANInterfaceDiscoveryService.java
+++ b/bundles/org.connectorio.addons.binding.can/src/main/java/org/connectorio/addons/binding/can/internal/discovery/DBusCANInterfaceDiscoveryService.java
@@ -114,7 +114,7 @@ public class DBusCANInterfaceDiscoveryService extends AbstractDiscoveryService i
     }
   }
 
-  @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+  @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
   public void addDiscoveryDelegate(CANInterfaceDiscoveryDelegate participant) {
     participants.add(participant);
   }

--- a/bundles/org.connectorio.addons.binding.canopen/src/main/java/org/connectorio/addons/binding/canopen/internal/handler/CoThingHandlerFactory.java
+++ b/bundles/org.connectorio.addons.binding.canopen/src/main/java/org/connectorio/addons/binding/canopen/internal/handler/CoThingHandlerFactory.java
@@ -66,7 +66,7 @@ public class CoThingHandlerFactory extends BaseThingHandlerFactory implements Th
     return null;
   }
 
-  @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+  @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
   public void addDiscoveryParticipant(CoDiscoveryParticipant participant) {
     participants.add(participant);
   }

--- a/bundles/org.connectorio.addons.persistence.manager/src/main/java/org/connectorio/addons/persistence/manager/PersistenceMarker.java
+++ b/bundles/org.connectorio.addons.persistence.manager/src/main/java/org/connectorio/addons/persistence/manager/PersistenceMarker.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024-2024 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.persistence.manager;
+
+import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.StartLevelService;
+
+/**
+ * {@link ReadyMarker} types by persistence related trackers.
+ */
+public interface PersistenceMarker {
+
+  /**
+   * Dedicated start level which indicate that all necessary persistence services are active.
+   */
+  ReadyMarker PERSISTENCE_START_LEVEL = new ReadyMarker(StartLevelService.STARTLEVEL_MARKER_TYPE, "11");
+
+  /**
+   * Named ready marker used to inform that all persistence services are active, same as above start level.
+   */
+  ReadyMarker PERSISTENCE_SERVICES = new ReadyMarker("co7io-persistence", "services");
+
+  /**
+   * Indicates that persistence services have been configured by persistence manager extension.
+   */
+  ReadyMarker PERSISTENCE_CONFIGURE = new ReadyMarker("co7io-persistence", "configure");
+
+
+
+}

--- a/bundles/org.connectorio.addons.persistence.manager/src/main/java/org/connectorio/addons/persistence/manager/internal/PersistenceConfigOptionsProvider.java
+++ b/bundles/org.connectorio.addons.persistence.manager/src/main/java/org/connectorio/addons/persistence/manager/internal/PersistenceConfigOptionsProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2024-2024 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.persistence.manager.internal;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import org.openhab.core.config.core.ConfigOptionProvider;
+import org.openhab.core.config.core.ParameterOption;
+import org.openhab.core.persistence.PersistenceService;
+import org.openhab.core.persistence.PersistenceServiceRegistry;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * A handy way to provide tooling for persistence services within configuration windows.
+ */
+@Component(service = ConfigOptionProvider.class)
+public class PersistenceConfigOptionsProvider implements ConfigOptionProvider {
+
+  private final String PARAMETER_PERSISTENCE_TARGET = "persistenceTarget";
+  private final String PARAMETER_PERSISTENCE_TARGETS = "persistenceTargets";
+  private final String PARAMETER_PERSISTENCE_SOURCE = "persistenceSource";
+  private final String PARAMETER_PERSISTENCE_SOURCES = "persistenceSources";
+
+  private final Set<String> properties = new HashSet<>(Arrays.asList(
+    PARAMETER_PERSISTENCE_TARGET,
+    PARAMETER_PERSISTENCE_TARGETS,
+    PARAMETER_PERSISTENCE_SOURCE,
+    PARAMETER_PERSISTENCE_SOURCES
+  ));
+
+  private final PersistenceServiceRegistry serviceRegistry;
+
+  @Activate
+  public PersistenceConfigOptionsProvider(@Reference PersistenceServiceRegistry serviceRegistry) {
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  @Override
+  public Collection<ParameterOption> getParameterOptions(URI uri, String param, String context, Locale locale) {
+    String configDescriptor = uri.toString();
+    if ((configDescriptor.contains("connectorio") || configDescriptor.contains("co7io") || configDescriptor.contains("metadata:")) && properties.contains(param)) {
+      Set<ParameterOption> options = new HashSet<>();
+      for (PersistenceService service : serviceRegistry.getAll()) {
+        options.add(new ParameterOption(service.getId(), service.getLabel(locale)));
+      }
+      return options;
+    }
+    return null;
+  }
+}

--- a/bundles/org.connectorio.addons.persistence.manager/src/main/java/org/connectorio/addons/persistence/manager/internal/PersistenceConfigOptionsProviderFactory.java
+++ b/bundles/org.connectorio.addons.persistence.manager/src/main/java/org/connectorio/addons/persistence/manager/internal/PersistenceConfigOptionsProviderFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024-2024 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.persistence.manager.internal;
+
+import org.connectorio.addons.persistence.manager.PersistenceMarker;
+import org.openhab.core.config.core.ConfigOptionProvider;
+import org.openhab.core.persistence.PersistenceServiceRegistry;
+import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.ReadyMarkerFilter;
+import org.openhab.core.service.ReadyService;
+import org.openhab.core.service.ReadyService.ReadyTracker;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Factory of {@link ConfigOptionProvider} which provide options pointing available persistence
+ * services.
+ */
+@Component(immediate = true)
+public class PersistenceConfigOptionsProviderFactory implements ReadyTracker {
+
+  private final ReadyService readyService;
+  private final PersistenceServiceRegistry persistenceRegistry;
+  private final BundleContext context;
+  private ServiceRegistration<?> registration;
+
+  @Activate
+  public PersistenceConfigOptionsProviderFactory(@Reference ReadyService readyService,
+    @Reference PersistenceServiceRegistry persistenceRegistry, BundleContext context) {
+    this.readyService = readyService;
+    this.persistenceRegistry = persistenceRegistry;
+    this.context = context;
+
+    this.readyService.registerTracker(this, new ReadyMarkerFilter()
+        .withType(PersistenceMarker.PERSISTENCE_SERVICES.getType())
+        .withIdentifier(PersistenceMarker.PERSISTENCE_SERVICES.getIdentifier())
+    );
+  }
+
+  @Override
+  public void onReadyMarkerAdded(ReadyMarker readyMarker) {
+    registration = context.registerService(ConfigOptionProvider.class, new PersistenceConfigOptionsProvider(persistenceRegistry), null);
+  }
+
+  @Override
+  public void onReadyMarkerRemoved(ReadyMarker readyMarker) {
+    if (registration != null) {
+      registration.unregister();
+    }
+  }
+
+}

--- a/bundles/org.connectorio.addons.persistence.manager/src/main/java/org/connectorio/addons/persistence/manager/internal/PersistenceServiceReadyMarker.java
+++ b/bundles/org.connectorio.addons.persistence.manager/src/main/java/org/connectorio/addons/persistence/manager/internal/PersistenceServiceReadyMarker.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024-2024 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.persistence.manager.internal;
+
+import org.connectorio.addons.persistence.manager.PersistenceMarker;
+import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.ReadyMarkerFilter;
+import org.openhab.core.service.ReadyService;
+import org.openhab.core.service.ReadyService.ReadyTracker;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Ready marker which translates custom start level into named ready marker.
+ */
+@Component(immediate = true)
+public class PersistenceServiceReadyMarker implements ReadyTracker {
+
+  private final ReadyService readService;
+
+  @Activate
+  public PersistenceServiceReadyMarker(@Reference ReadyService readyService) {
+    this.readService = readyService;
+    readyService.registerTracker(this, new ReadyMarkerFilter()
+      .withType(PersistenceMarker.PERSISTENCE_START_LEVEL.getType())
+      .withIdentifier(PersistenceMarker.PERSISTENCE_START_LEVEL.getIdentifier()));
+  }
+
+  @Override
+  public void onReadyMarkerAdded(ReadyMarker readyMarker) {
+    readService.markReady(PersistenceMarker.PERSISTENCE_SERVICES);
+  }
+
+  @Override
+  public void onReadyMarkerRemoved(ReadyMarker readyMarker) {
+    readService.markReady(PersistenceMarker.PERSISTENCE_SERVICES);
+  }
+
+}


### PR DESCRIPTION
Added dedicated config option provider and ready markers for re-use.

During debug session it turned out that persistence manager extension was bound to only single persistence service. While it was expecting more, only one was wired and configured. This lead to situations where system had incomplete configuration, despite of valid inputs. Additionally same bug was spotted in few more places which got fixed as well.