### PR TITLE
Add support for array values within configuration inputs.

### DIFF
--- a/bundles/org.connectorio.addons.config/src/main/java/org/connectorio/addons/config/internal/ConfigMapperHack.java
+++ b/bundles/org.connectorio.addons.config/src/main/java/org/connectorio/addons/config/internal/ConfigMapperHack.java
@@ -1,6 +1,12 @@
 package org.connectorio.addons.config.internal;
 
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import org.connectorio.addons.config.ConfigMapper;
 import org.openhab.core.config.core.Configuration;
 
@@ -14,12 +20,37 @@ public class ConfigMapperHack<T> implements ConfigMapper<T> {
 
   @Override
   public T map(Map<String, Object> configuration) {
-    return org.openhab.core.config.core.internal.ConfigMapper.as(configuration, type);
+    return org.openhab.core.config.core.internal.ConfigMapper.as(cleanup(configuration), type);
   }
 
   @Override
   public T map(Configuration configuration) {
     return map(configuration.getProperties());
+  }
+
+  /**
+   * Regular config mapper available in OH core can not handle arrays.
+   * This cleanup method transform array entries into list to avoid failures.
+    */
+  private static Map<String, Object> cleanup(Map<String, Object> configuration) {
+    Map<String, Object> config = new HashMap<>();
+    for (Entry<String, Object> entry : configuration.entrySet()) {
+      if (entry.getValue().getClass().isArray()) {
+        config.put(entry.getKey(), list(entry.getValue()));
+      } else {
+        config.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return config;
+  }
+
+  private static List<Object> list(Object value) {
+    int length = Array.getLength(value);
+    List<Object> list = new ArrayList<>(length);
+    for (int index = 0; index < length; index++) {
+      list.add(Array.get(value, index));
+    }
+    return list;
   }
 
 }


### PR DESCRIPTION
Some of multi-valued properties might come back as an array, hence config mapper layer should accept them.