### PR TITLE
First push of more advanced version of OCPP binding.

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/OcppBindingConstants.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/OcppBindingConstants.java
@@ -21,7 +21,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import org.connectorio.addons.binding.BaseBindingConstants;
+import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.UID;
+import org.openhab.core.thing.type.ChannelTypeRegistry;
+import org.openhab.core.thing.type.ChannelTypeUID;
 
 public interface OcppBindingConstants extends BaseBindingConstants {
 
@@ -36,5 +40,41 @@ public interface OcppBindingConstants extends BaseBindingConstants {
     CHARGER_THING_TYPE,
     CONNECTOR_THING_TYPE
   ));
+
+  // common channel types
+  ChannelRef CURRENT_EXPORT = new ChannelRef("currentExport");
+  ChannelRef CURRENT_IMPORT = new ChannelRef("currentImport");
+  ChannelRef CURRENT_OFFERED = new ChannelRef("currentOffered");
+  ChannelRef ENERGY_ACTIVE_EXPORT = new ChannelRef("energyActiveExport");
+  ChannelRef ENERGY_ACTIVE_IMPORT = new ChannelRef("energyActiveImport");
+  ChannelRef ENERGY_REACTIVE_EXPORT = new ChannelRef("energyReactiveExport");
+  ChannelRef ENERGY_REACTIVE_IMPORT = new ChannelRef("energyReactiveImport");
+  ChannelRef ENERGY_ACTIVE_EXPORT_INTERVAL = new ChannelRef("energyActiveExportInterval");
+  ChannelRef ENERGY_ACTIVE_IMPORT_INTERVAL = new ChannelRef("energyActiveImportInterval");
+  ChannelRef ENERGY_REACTIVE_EXPORT_INTERVAL = new ChannelRef("energyReactiveExportInterval");
+  ChannelRef ENERGY_REACTIVE_IMPORT_INTERVAL = new ChannelRef("energyReactiveImportInterval");
+  ChannelRef FREQUENCY = new ChannelRef("frequency");
+  ChannelRef POWER_ACTIVE_EXPORT = new ChannelRef("powerActiveExport");
+  ChannelRef POWER_ACTIVE_IMPORT = new ChannelRef("powerActiveImport");
+  ChannelRef POWER_FACTOR = new ChannelRef("powerFactor");
+  ChannelRef POWER_OFFERED = new ChannelRef("powerOffered");
+  ChannelRef POWER_REACTIVE_EXPORT = new ChannelRef("powerReactiveExport");
+  ChannelRef POWER_REACTIVE_IMPORT = new ChannelRef("powerReactiveImport");
+  ChannelRef RPM = new ChannelRef("rpm");
+  ChannelRef SOC = new ChannelRef("soc");
+  ChannelRef TEMPERATURE = new ChannelRef("temperature");
+  ChannelRef VOLTAGE = new ChannelRef("voltage");
+
+  static class ChannelRef extends UID {
+
+    public ChannelRef(String uid) {
+      super(uid);
+    }
+
+    @Override
+    protected int getMinimalNumberOfSegments() {
+      return 1;
+    }
+  }
 
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/OcppSender.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/OcppSender.java
@@ -21,9 +21,10 @@ import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
+import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
 
 public interface OcppSender {
 
-  <T extends Confirmation> CompletionStage<T> send(UUID sessionIndex, Request request);
+  <T extends Confirmation> CompletionStage<T> send(ChargerReference reference, Request request);
 
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/discovery/OcppChargerConnectorDiscoveryService.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/discovery/OcppChargerConnectorDiscoveryService.java
@@ -1,0 +1,69 @@
+package org.connectorio.addons.binding.ocpp.internal.discovery;
+
+import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
+import java.util.Collections;
+import org.connectorio.addons.binding.ocpp.OcppBindingConstants;
+import org.connectorio.addons.binding.ocpp.internal.OcppRequestListener;
+import org.connectorio.addons.binding.ocpp.internal.handler.ChargerThingHandler;
+import org.openhab.core.config.discovery.AbstractDiscoveryService;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
+
+import org.openhab.core.config.discovery.DiscoveryService;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+
+public class OcppChargerConnectorDiscoveryService extends AbstractDiscoveryService implements DiscoveryService,
+  ThingHandlerService, OcppRequestListener<StatusNotificationRequest> {
+
+  private ChargerThingHandler thingHandler;
+
+  public OcppChargerConnectorDiscoveryService() {
+    super(Collections.singleton(OcppBindingConstants.CONNECTOR_THING_TYPE), 30, true);
+  }
+
+  @Override
+  protected void startScan() {
+  }
+
+  @Override
+  public void setThingHandler(ThingHandler handler){
+    if (handler instanceof ChargerThingHandler) {
+      thingHandler = (ChargerThingHandler) handler;
+      thingHandler.addRequestListener(StatusNotificationRequest.class, this);
+    }
+  }
+
+  @Override
+  public ThingHandler getThingHandler() {
+    return thingHandler;
+  }
+
+  @Override
+  public void activate() {
+    ThingHandlerService.super.activate();
+  }
+
+  @Override
+  public void deactivate() {
+    thingHandler.removeRequestListener(this);
+    ThingHandlerService.super.deactivate();
+  }
+
+  @Override
+  public void onRequest(StatusNotificationRequest request) {
+    ThingUID bridgeUid = thingHandler.getThing().getUID();
+
+    Integer connectorId = request.getConnectorId();
+    if (connectorId != null && connectorId > 0) {
+      // connectorId = 0 indicates status of charge point controller
+      ThingUID thingUID = new ThingUID(OcppBindingConstants.CONNECTOR_THING_TYPE, bridgeUid, "" + connectorId);
+      DiscoveryResultBuilder resultBuilder = DiscoveryResultBuilder.create(thingUID)
+        .withBridge(bridgeUid)
+        .withProperty("connectorId", connectorId)
+        .withRepresentationProperty("connectorId")
+        .withLabel("Connector #" + request.getConnectorId());
+      thingDiscovered(resultBuilder.build());
+    }
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/discovery/OcppChargerDiscoveryService.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/discovery/OcppChargerDiscoveryService.java
@@ -75,7 +75,7 @@ public class OcppChargerDiscoveryService extends AbstractDiscoveryService implem
     DiscoveryResultBuilder resultBuilder = DiscoveryResultBuilder.create(thingUID)
       .withBridge(bridgeUid)
       .withProperty(Thing.PROPERTY_MODEL_ID, request.getChargePointModel())
-      .withProperty(Thing.PROPERTY_SERIAL_NUMBER, request.getMeterSerialNumber())
+      .withProperty(Thing.PROPERTY_SERIAL_NUMBER, request.getChargePointSerialNumber())
       .withProperty(Thing.PROPERTY_VENDOR, request.getChargePointVendor())
       .withProperty(Thing.PROPERTY_FIRMWARE_VERSION, request.getFirmwareVersion())
       .withRepresentationProperty(Thing.PROPERTY_SERIAL_NUMBER)

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerConnectorAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerConnectorAdapter.java
@@ -1,0 +1,89 @@
+package org.connectorio.addons.binding.ocpp.internal.handler;
+
+import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.core.MeterValuesConfirmation;
+import eu.chargetime.ocpp.model.core.MeterValuesRequest;
+import eu.chargetime.ocpp.model.core.StartTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StartTransactionRequest;
+import eu.chargetime.ocpp.model.core.StatusNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
+import eu.chargetime.ocpp.model.core.StopTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StopTransactionRequest;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import org.connectorio.addons.binding.ocpp.internal.OcppRequestListener;
+import org.connectorio.addons.binding.ocpp.internal.server.listener.MeterValuesHandler;
+import org.connectorio.addons.binding.ocpp.internal.server.listener.StatusNotificationHandler;
+import org.connectorio.addons.binding.ocpp.internal.server.listener.TransactionHandler;
+
+public class ChargerConnectorAdapter implements StatusNotificationHandler, MeterValuesHandler,
+  TransactionHandler {
+
+  private final Map<Integer, ConnectorThingHandler> handlers = new ConcurrentHashMap<>();
+  private final Map<Integer, Integer> transactionMap = new ConcurrentHashMap<>();
+  private final OcppRequestListener<Request> listener;
+
+  public ChargerConnectorAdapter(OcppRequestListener<Request> listener) {
+    this.listener = listener;
+  }
+
+  public void addConnector(int connector, ConnectorThingHandler handler) {
+    handlers.put(connector, handler);
+  }
+
+  public void removeConnector(int connector) {
+    handlers.remove(connector);
+  }
+
+  @Override
+  public StatusNotificationConfirmation handleStatusNotification(StatusNotificationRequest request) {
+    listener.onRequest(request);
+    return handle(handler -> handler.handleStatusNotification(request), request.getConnectorId());
+  }
+
+  @Override
+  public MeterValuesConfirmation handleMeterValues(MeterValuesRequest request) {
+    listener.onRequest(request);
+    return handle(handler -> handler.handleMeterValues(request), request.getConnectorId());
+  }
+
+  @Override
+  public StartTransactionConfirmation handleStartTransaction(StartTransactionRequest request) {
+    listener.onRequest(request);
+
+    StartTransactionConfirmation confirmation = handle(handler -> handler.handleStartTransaction(request), request.getConnectorId());
+    if (confirmation != null) {
+      transactionMap.put(request.getConnectorId(), confirmation.getTransactionId());
+    }
+    return confirmation;
+  }
+
+  @Override
+  public StopTransactionConfirmation handleStopTransaction(StopTransactionRequest request) {
+    listener.onRequest(request);
+    Integer connectorId = null;
+    for (Entry<Integer, Integer> entry : transactionMap.entrySet()) {
+      if (entry.getValue().equals(request.getTransactionId())) {
+        connectorId = entry.getKey();
+      }
+    }
+
+    if (connectorId != null) {
+      return handle(handler -> handler.handleStopTransaction(request), connectorId);
+    }
+    // unknown transaction
+    return null;
+  }
+
+  private <C> C handle(Function<ConnectorThingHandler, C> handler, int connector) {
+    if (handlers.containsKey(connector)) {
+      ConnectorThingHandler connectorHandler = handlers.get(connector);
+      return handler.apply(connectorHandler);
+    }
+
+    return null;
+  }
+
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerThingHandler.java
@@ -17,27 +17,150 @@
  */
 package org.connectorio.addons.binding.ocpp.internal.handler;
 
-import org.connectorio.addons.binding.handler.GenericThingHandlerBase;
-import org.connectorio.addons.binding.handler.polling.common.BasePollingThingHandler;
+import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.core.HeartbeatConfirmation;
+import eu.chargetime.ocpp.model.core.HeartbeatRequest;
+import eu.chargetime.ocpp.model.core.MeterValuesConfirmation;
+import eu.chargetime.ocpp.model.core.MeterValuesRequest;
+import eu.chargetime.ocpp.model.core.StartTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StartTransactionRequest;
+import eu.chargetime.ocpp.model.core.StatusNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
+import eu.chargetime.ocpp.model.core.StopTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StopTransactionRequest;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collection;
+import org.connectorio.addons.binding.handler.GenericBridgeHandlerBase;
+import org.connectorio.addons.binding.ocpp.internal.OcppAttendant;
+import org.connectorio.addons.binding.ocpp.internal.OcppRequestListener;
 import org.connectorio.addons.binding.ocpp.internal.config.ChargerConfig;
+import org.connectorio.addons.binding.ocpp.internal.discovery.OcppChargerConnectorDiscoveryService;
+import org.connectorio.addons.binding.ocpp.internal.server.CompositeRequestListener;
+import org.connectorio.addons.binding.ocpp.internal.server.listener.HeartbeatHandler;
+import org.connectorio.addons.binding.ocpp.internal.server.listener.MeterValuesHandler;
+import org.connectorio.addons.binding.ocpp.internal.server.listener.StatusNotificationHandler;
+import org.connectorio.addons.binding.ocpp.internal.server.listener.TransactionHandler;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
 import org.openhab.core.types.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class ChargerThingHandler extends GenericThingHandlerBase<ServerBridgeHandler, ChargerConfig> {
+public class ChargerThingHandler extends GenericBridgeHandlerBase<ChargerConfig> implements
+  HeartbeatHandler, StatusNotificationHandler, TransactionHandler, MeterValuesHandler,
+  OcppAttendant {
 
-  public ChargerThingHandler(Thing thing) {
-    super(thing);
+  private final Logger logger = LoggerFactory.getLogger(ConnectorThingHandler.class);
+  private final CompositeRequestListener listener = new CompositeRequestListener();
+  private final ChargerConnectorAdapter adapter = new ChargerConnectorAdapter(listener);
+
+  public ChargerThingHandler(Bridge bridge) {
+    super(bridge);
   }
+
 
   @Override
   public void initialize() {
+    updateStatus(ThingStatus.ONLINE);
+  }
 
+  @Override
+  public void dispose() {
   }
 
   @Override
   public void handleCommand(ChannelUID channelUID, Command command) {
 
   }
+
+  @Override
+  public Collection<Class<? extends ThingHandlerService>> getServices() {
+    return Arrays.asList(OcppChargerConnectorDiscoveryService.class);
+  }
+
+  @Override
+  public HeartbeatConfirmation handleHeartbeat(HeartbeatRequest request) {
+    updateStatus(ThingStatus.ONLINE);
+    return new HeartbeatConfirmation(ZonedDateTime.now());
+  }
+
+  @Override
+  public MeterValuesConfirmation handleMeterValues(MeterValuesRequest request) {
+    updateStatus(ThingStatus.ONLINE);
+    return adapter.handleMeterValues(request);
+  }
+
+  @Override
+  public StatusNotificationConfirmation handleStatusNotification(StatusNotificationRequest request) {
+    updateStatus(ThingStatus.ONLINE);
+
+    StatusNotificationConfirmation confirmation = adapter.handleStatusNotification(request);
+
+    if (confirmation == null) {
+      return new StatusNotificationConfirmation();
+    }
+    return confirmation;
+  }
+
+  @Override
+  public StartTransactionConfirmation handleStartTransaction(StartTransactionRequest request) {
+    updateStatus(ThingStatus.ONLINE);
+    return adapter.handleStartTransaction(request);
+  }
+
+  @Override
+  public StopTransactionConfirmation handleStopTransaction(StopTransactionRequest request) {
+    updateStatus(ThingStatus.ONLINE);
+    return adapter.handleStopTransaction(request);
+  }
+
+  @Override
+  public void childHandlerInitialized(ThingHandler childHandler, Thing childThing) {
+    if (childHandler instanceof ConnectorThingHandler) {
+      Integer connectorId = getConnectorId(childThing);
+      if (connectorId != null) {
+        adapter.addConnector(connectorId, (ConnectorThingHandler) childHandler);
+      }
+    }
+  }
+
+  @Override
+  public void childHandlerDisposed(ThingHandler childHandler, Thing childThing) {
+    Integer connectorId = getConnectorId(childThing);
+    if (connectorId != null) {
+      adapter.removeConnector(connectorId);
+    }
+  }
+
+  @Override
+  public <T extends Request> boolean addRequestListener(Class<T> type, OcppRequestListener<T> listener) {
+    return this.listener.addRequestListener(type, listener);
+  }
+
+  @Override
+  public <T extends Request> void removeRequestListener(OcppRequestListener<T> listener) {
+    this.listener.removeRequestListener(listener);
+  }
+
+  private Integer getConnectorId(Thing childThing) {
+    Object connectorId = childThing.getConfiguration().get("connectorId");
+    if (connectorId instanceof Number) {
+      return ((Number) connectorId).intValue();
+    }
+    if (connectorId instanceof String) {
+      try {
+        return Integer.parseInt((String) connectorId);
+      } catch (NumberFormatException e) {
+        logger.warn("Invalid format of connectorId config parameter {}", connectorId, e);
+        return null;
+      }
+    }
+    return null;
+  }
+
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -1,0 +1,159 @@
+package org.connectorio.addons.binding.ocpp.internal.handler;
+
+import eu.chargetime.ocpp.model.core.AuthorizationStatus;
+import eu.chargetime.ocpp.model.core.ChargePointStatus;
+import eu.chargetime.ocpp.model.core.IdTagInfo;
+import eu.chargetime.ocpp.model.core.MeterValue;
+import eu.chargetime.ocpp.model.core.MeterValuesConfirmation;
+import eu.chargetime.ocpp.model.core.MeterValuesRequest;
+import eu.chargetime.ocpp.model.core.SampledValue;
+import eu.chargetime.ocpp.model.core.StartTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StartTransactionRequest;
+import eu.chargetime.ocpp.model.core.StatusNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
+import eu.chargetime.ocpp.model.core.StopTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StopTransactionRequest;
+import eu.chargetime.ocpp.model.core.ValueFormat;
+import java.time.ZonedDateTime;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.connectorio.addons.binding.handler.GenericThingHandlerBase;
+import org.connectorio.addons.binding.ocpp.internal.config.ChargerConfig;
+import org.connectorio.addons.binding.ocpp.internal.server.OcppMeasurementMapping;
+import org.connectorio.addons.binding.ocpp.internal.server.listener.MeterValuesHandler;
+import org.connectorio.addons.binding.ocpp.internal.server.listener.StatusNotificationHandler;
+import org.connectorio.addons.binding.ocpp.internal.server.listener.TransactionHandler;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.Units;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.UID;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tec.uom.se.ComparableQuantity;
+import tec.uom.se.quantity.Quantities;
+
+public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeHandler, ChargerConfig> implements
+  StatusNotificationHandler, TransactionHandler, MeterValuesHandler {
+
+  private final AtomicInteger transactionId = new AtomicInteger();
+  private final Logger logger = LoggerFactory.getLogger(ConnectorThingHandler.class);
+
+  public ConnectorThingHandler(Thing thing) {
+    super(thing);
+  }
+
+  @Override
+  public void initialize() {
+    updateStatus(ThingStatus.ONLINE);
+  }
+
+  @Override
+  public void handleCommand(ChannelUID channelUID, Command command) {
+
+  }
+
+  @Override
+  public MeterValuesConfirmation handleMeterValues(MeterValuesRequest request) {
+    ThingHandlerCallback callback = getCallback();
+
+    // push transaction id
+    Integer transactionId = request.getTransactionId();
+    callback.stateUpdated(new ChannelUID(getThing().getUID(), "transactionId"), new DecimalType(transactionId));
+
+    for (MeterValue value : request.getMeterValue()) {
+      ZonedDateTime timestamp = value.getTimestamp();
+      // update timestamp for further channel updates
+      callback.stateUpdated(new ChannelUID(getThing().getUID(), "timestamp"), new DateTimeType(timestamp));
+
+      logger.debug("Received samples for transaction {}: {}", transactionId, value);
+
+      for (SampledValue sample : value.getSampledValue()) {
+        if (!ValueFormat.Raw.equals(sample.getFormat())) {
+          // unsupported case with encrypted measurements
+          continue;
+        }
+
+        try {
+          Double measurement = Double.valueOf(sample.getValue());
+          UID ref = OcppMeasurementMapping.get(sample.getMeasurand());
+          if (ref != null) {
+            ChannelUID uid = new ChannelUID(getThing().getUID(), ref.getAsString());
+            State state = parse(measurement, uid, sample);
+            getCallback().stateUpdated(uid, state);
+          }
+        } catch (NumberFormatException e) {
+          logger.debug("Could not parse value of measurement {}", sample, e);
+        }
+      }
+    }
+
+    return new MeterValuesConfirmation();
+  }
+
+  @Override
+  public StatusNotificationConfirmation handleStatusNotification(StatusNotificationRequest request) {
+    ChargePointStatus status = request.getStatus();
+
+    StringType val = new StringType(status.name());
+    getCallback().stateUpdated(new ChannelUID(getThing().getUID(), "chargePointStatus"), val);
+
+    return new StatusNotificationConfirmation();
+  }
+
+  @Override
+  public StartTransactionConfirmation handleStartTransaction(StartTransactionRequest request) {
+    String tag = request.getIdTag();
+
+    ThingHandlerCallback callback = getCallback();
+    callback.stateUpdated(new ChannelUID(getThing().getUID(), "idTag"), new StringType(tag));
+    callback.stateUpdated(new ChannelUID(getThing().getUID(), "timestampStart"), new DateTimeType(request.getTimestamp()));
+    callback.stateUpdated(new ChannelUID(getThing().getUID(), "meterStart"), new QuantityType<>(request.getMeterStart(), Units.WATT_HOUR));
+
+    IdTagInfo tagInfo = new IdTagInfo(AuthorizationStatus.Accepted);
+    return new StartTransactionConfirmation(tagInfo, generateId());
+  }
+
+  @Override
+  public StopTransactionConfirmation handleStopTransaction(StopTransactionRequest request) {
+    String tag = request.getIdTag();
+
+    Integer txId = request.getTransactionId();
+    if (transactionId.get() != txId + 1) {
+      return new StopTransactionConfirmation();
+    }
+
+    ThingHandlerCallback callback = getCallback();
+    callback.stateUpdated(new ChannelUID(getThing().getUID(), "idTag"), new StringType(tag));
+    callback.stateUpdated(new ChannelUID(getThing().getUID(), "timestampStop"), new DateTimeType(request.getTimestamp()));
+    callback.stateUpdated(new ChannelUID(getThing().getUID(), "meterStop"), new QuantityType<>(request.getMeterStop(), Units.WATT_HOUR));
+
+    return new StopTransactionConfirmation();
+  }
+
+  private static State parse(Double measurement, ChannelUID uid, SampledValue sample) {
+    String unit = sample.getUnit();
+    if (unit != null) {
+      ComparableQuantity<?> quantity = Quantities.getQuantity("1 " + unit);
+      return new QuantityType<>(measurement, quantity.getUnit());
+    }
+
+    // default assumed from specs, when unit is not specified it fall backs to "Wh"
+    return new QuantityType<>(measurement, Units.WATT_HOUR);
+  }
+
+  private int generateId() {
+    int transaction = transactionId.getAndIncrement();
+    if (transaction == Integer.MAX_VALUE) {
+      transactionId.set(0);
+    }
+    return transaction;
+  }
+
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/OcppThingHandlerFactory.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/OcppThingHandlerFactory.java
@@ -45,10 +45,13 @@ public class OcppThingHandlerFactory extends BaseThingHandlerFactory implements 
       if (thing.getThingTypeUID().equals(OcppBindingConstants.SERVER_THING_TYPE)) {
         return new ServerBridgeHandler((Bridge) thing, networkAddressService);
       }
-    } else {
       if (thing.getThingTypeUID().equals(OcppBindingConstants.CHARGER_THING_TYPE)) {
-        return new ChargerThingHandler(thing);
+        return new ChargerThingHandler((Bridge) thing);
       }
+    }
+
+    if (thing.getThingTypeUID().equals(OcppBindingConstants.CONNECTOR_THING_TYPE)) {
+      return new ConnectorThingHandler(thing);
     }
     return null;
   }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ServerBridgeDispatcherAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ServerBridgeDispatcherAdapter.java
@@ -1,0 +1,75 @@
+package org.connectorio.addons.binding.ocpp.internal.handler;
+
+import eu.chargetime.ocpp.model.Confirmation;
+import eu.chargetime.ocpp.model.core.HeartbeatConfirmation;
+import eu.chargetime.ocpp.model.core.HeartbeatRequest;
+import eu.chargetime.ocpp.model.core.MeterValuesConfirmation;
+import eu.chargetime.ocpp.model.core.MeterValuesRequest;
+import eu.chargetime.ocpp.model.core.StartTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StartTransactionRequest;
+import eu.chargetime.ocpp.model.core.StatusNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
+import eu.chargetime.ocpp.model.core.StopTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StopTransactionRequest;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
+import org.connectorio.addons.binding.ocpp.internal.server.OcppChargerSessionRegistry;
+import org.connectorio.addons.binding.ocpp.internal.server.adapter.CoreEventHandlerAdapter;
+
+public class ServerBridgeDispatcherAdapter extends CoreEventHandlerAdapter {
+
+  private final Map<ChargerReference, ChargerThingHandler> handlers = new ConcurrentHashMap<>();
+  private final OcppChargerSessionRegistry sessionRegistry;
+
+  public ServerBridgeDispatcherAdapter(OcppChargerSessionRegistry sessionRegistry) {
+    this.sessionRegistry = sessionRegistry;
+  }
+
+  public void addHandler(ChargerReference reference, ChargerThingHandler handler) {
+    this.handlers.put(reference, handler);
+  }
+
+  public void removeHandler(ChargerReference reference) {
+    this.handlers.remove(reference);
+  }
+
+  @Override
+  public HeartbeatConfirmation handleHeartbeatRequest(UUID sessionIndex, HeartbeatRequest request) {
+    return handle(sessionIndex, handler -> handler.handleHeartbeat(request));
+  }
+
+  @Override
+  public MeterValuesConfirmation handleMeterValuesRequest(UUID sessionIndex, MeterValuesRequest request) {
+    return handle(sessionIndex, handler -> handler.handleMeterValues(request));
+  }
+
+  @Override
+  public StartTransactionConfirmation handleStartTransactionRequest(UUID sessionIndex, StartTransactionRequest request) {
+    return handle(sessionIndex, handler -> handler.handleStartTransaction(request));
+  }
+
+  @Override
+  public StatusNotificationConfirmation handleStatusNotificationRequest(UUID sessionIndex, StatusNotificationRequest request) {
+    return handle(sessionIndex, handler -> handler.handleStatusNotification(request));
+  }
+
+  @Override
+  public StopTransactionConfirmation handleStopTransactionRequest(UUID sessionIndex, StopTransactionRequest request) {
+    return handle(sessionIndex, handler -> handler.handleStopTransaction(request));
+  }
+
+  private <C extends Confirmation> C handle(UUID sessionIndex, Function<ChargerThingHandler, C> consumer) {
+    ChargerReference charger = sessionRegistry.getCharger(sessionIndex);
+    if (charger != null) {
+      ChargerThingHandler handler = handlers.get(charger);
+      if (handler != null) {
+        return consumer.apply(handler);
+      }
+    }
+    return null;
+  }
+
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/ChargerReference.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/ChargerReference.java
@@ -1,0 +1,37 @@
+package org.connectorio.addons.binding.ocpp.internal.server;
+
+import java.util.Objects;
+
+public class ChargerReference {
+
+  private final String serial;
+
+  public ChargerReference(String serial) {
+    this.serial = serial;
+  }
+
+  public String getSerial() {
+    return serial;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ChargerReference)) {
+      return false;
+    }
+    return Objects.equals(serial, ((ChargerReference) o).serial);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(serial);
+  }
+
+  public String toString() {
+    return "Charger [SN: " + serial + "]";
+  }
+
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/ConfigKeyConstants.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/ConfigKeyConstants.java
@@ -1,0 +1,14 @@
+package org.connectorio.addons.binding.ocpp.internal.server;
+
+public interface ConfigKeyConstants {
+
+  // 4
+  String NUMBER_OF_CONNECTORS = "numberOfConnectors";
+  // Core,LocalAuthListManagement,RemoteTrigger,SoC
+  String SUPPORTED_FEATURE_PROFILES = "supportedFeatureProfiles";
+  // 60
+  String HEARTBEAT_INTERVAL = "heartbeatInterval";
+  // 60
+  String METER_VALUE_INTERVAL = "meterValueInterval";
+
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/CoreEventHandlerWrapper.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/CoreEventHandlerWrapper.java
@@ -1,0 +1,86 @@
+package org.connectorio.addons.binding.ocpp.internal.server;
+
+import eu.chargetime.ocpp.feature.profile.ServerCoreEventHandler;
+import eu.chargetime.ocpp.model.Confirmation;
+import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.core.AuthorizeConfirmation;
+import eu.chargetime.ocpp.model.core.AuthorizeRequest;
+import eu.chargetime.ocpp.model.core.BootNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.BootNotificationRequest;
+import eu.chargetime.ocpp.model.core.DataTransferConfirmation;
+import eu.chargetime.ocpp.model.core.DataTransferRequest;
+import eu.chargetime.ocpp.model.core.HeartbeatConfirmation;
+import eu.chargetime.ocpp.model.core.HeartbeatRequest;
+import eu.chargetime.ocpp.model.core.MeterValuesConfirmation;
+import eu.chargetime.ocpp.model.core.MeterValuesRequest;
+import eu.chargetime.ocpp.model.core.StartTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StartTransactionRequest;
+import eu.chargetime.ocpp.model.core.StatusNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
+import eu.chargetime.ocpp.model.core.StopTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StopTransactionRequest;
+import java.util.Deque;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+public class CoreEventHandlerWrapper implements ServerCoreEventHandler {
+
+  private final Deque<ServerCoreEventHandler> handlers;
+
+  public CoreEventHandlerWrapper(Deque<ServerCoreEventHandler> handlers) {
+    this.handlers = handlers;
+  }
+
+  @Override
+  public AuthorizeConfirmation handleAuthorizeRequest(UUID sessionIndex, AuthorizeRequest request) {
+    return process(handler -> handler.handleAuthorizeRequest(sessionIndex, request));
+  }
+
+  @Override
+  public BootNotificationConfirmation handleBootNotificationRequest(UUID sessionIndex, BootNotificationRequest request) {
+    return process(handler -> handler.handleBootNotificationRequest(sessionIndex, request));
+  }
+
+  @Override
+  public DataTransferConfirmation handleDataTransferRequest(UUID sessionIndex, DataTransferRequest request) {
+    return process(handler -> handler.handleDataTransferRequest(sessionIndex, request));
+  }
+
+  @Override
+  public HeartbeatConfirmation handleHeartbeatRequest(UUID sessionIndex, HeartbeatRequest request) {
+    return process(handler -> handler.handleHeartbeatRequest(sessionIndex, request));
+  }
+
+  @Override
+  public MeterValuesConfirmation handleMeterValuesRequest(UUID sessionIndex, MeterValuesRequest request) {
+    return process(handler -> handler.handleMeterValuesRequest(sessionIndex, request));
+  }
+
+  @Override
+  public StartTransactionConfirmation handleStartTransactionRequest(UUID sessionIndex, StartTransactionRequest request) {
+    return process(handler -> handler.handleStartTransactionRequest(sessionIndex, request));
+  }
+
+  @Override
+  public StatusNotificationConfirmation handleStatusNotificationRequest(UUID sessionIndex, StatusNotificationRequest request) {
+    return process(handler -> handler.handleStatusNotificationRequest(sessionIndex, request));
+  }
+
+  @Override
+  public StopTransactionConfirmation handleStopTransactionRequest(UUID sessionIndex, StopTransactionRequest request) {
+    return process(handler -> handler.handleStopTransactionRequest(sessionIndex, request));
+  }
+
+  private <T extends Request, C extends Confirmation> C process(Function<ServerCoreEventHandler, C> consumer) {
+    C confirmation = null;
+    for (ServerCoreEventHandler handler : handlers) {
+      C handlerConfirmation = consumer.apply(handler);
+      if (confirmation == null && handlerConfirmation != null && handlerConfirmation.validate()) {
+        confirmation = handlerConfirmation;
+      }
+    }
+    return confirmation;
+  }
+
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppChargerConfigRegistry.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppChargerConfigRegistry.java
@@ -1,0 +1,9 @@
+package org.connectorio.addons.binding.ocpp.internal.server;
+
+import java.util.Map;
+
+public interface OcppChargerConfigRegistry {
+
+  Map<String, Object> getConfig(ChargerReference reference);
+
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppChargerSessionRegistry.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppChargerSessionRegistry.java
@@ -1,0 +1,12 @@
+package org.connectorio.addons.binding.ocpp.internal.server;
+
+import java.util.UUID;
+
+public interface OcppChargerSessionRegistry {
+
+  UUID getSession(ChargerReference chargerReference);
+
+  ChargerReference removeSession(UUID session);
+
+  ChargerReference getCharger(UUID sessionIndex);
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMapping.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMapping.java
@@ -1,0 +1,45 @@
+package org.connectorio.addons.binding.ocpp.internal.server;
+
+import static java.util.Map.entry;
+
+import java.util.Map;
+import org.connectorio.addons.binding.ocpp.OcppBindingConstants;
+import org.connectorio.addons.binding.ocpp.OcppBindingConstants.ChannelRef;
+import org.openhab.core.thing.UID;
+
+public class OcppMeasurementMapping {
+
+  private final static Map<String, ChannelRef> MAPPING = Map.ofEntries(
+    entry("Current.Export", OcppBindingConstants.CURRENT_EXPORT),
+    entry("Current.Import", OcppBindingConstants.CURRENT_IMPORT),
+    entry("Current.Offered", OcppBindingConstants.CURRENT_OFFERED),
+    entry("Energy.Active.Export.Register", OcppBindingConstants.ENERGY_ACTIVE_EXPORT),
+    entry("Energy.Active.Import.Register", OcppBindingConstants.ENERGY_ACTIVE_IMPORT),
+    entry("Energy.Reactive.Export.Register", OcppBindingConstants.ENERGY_REACTIVE_EXPORT),
+    entry("Energy.Reactive.Import.Register", OcppBindingConstants.ENERGY_REACTIVE_IMPORT),
+    entry("Energy.Active.Export.Interval", OcppBindingConstants.ENERGY_ACTIVE_EXPORT_INTERVAL),
+    entry("Energy.Active.Import.Interval", OcppBindingConstants.ENERGY_ACTIVE_IMPORT_INTERVAL),
+    entry("Energy.Reactive.Export.Interval", OcppBindingConstants.ENERGY_REACTIVE_EXPORT_INTERVAL),
+    entry("Energy.Reactive.Import.Interval", OcppBindingConstants.ENERGY_REACTIVE_IMPORT_INTERVAL),
+    entry("Frequency", OcppBindingConstants.FREQUENCY),
+    entry("Power.Active.Export", OcppBindingConstants.POWER_ACTIVE_EXPORT),
+    entry("Power.Active.Import", OcppBindingConstants.POWER_ACTIVE_IMPORT),
+    entry("Power.Factor", OcppBindingConstants.POWER_FACTOR),
+    entry("Power.Offered", OcppBindingConstants.POWER_OFFERED),
+    entry("Power.Reactive.Export", OcppBindingConstants.POWER_REACTIVE_EXPORT),
+    entry("Power.Reactive.Import", OcppBindingConstants.POWER_REACTIVE_IMPORT),
+    entry("RPM", OcppBindingConstants.RPM),
+    entry("SoC", OcppBindingConstants.SOC),
+    entry("Temperature", OcppBindingConstants.TEMPERATURE),
+    entry("Voltage", OcppBindingConstants.VOLTAGE)
+  );
+
+  public static UID get(String measurement) {
+    if (MAPPING.containsKey(measurement)) {
+      return MAPPING.get(measurement);
+    }
+
+    return null;
+  }
+
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/AuthorizationIdTagAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/AuthorizationIdTagAdapter.java
@@ -1,0 +1,29 @@
+package org.connectorio.addons.binding.ocpp.internal.server.adapter;
+
+import eu.chargetime.ocpp.model.core.AuthorizationStatus;
+import eu.chargetime.ocpp.model.core.AuthorizeConfirmation;
+import eu.chargetime.ocpp.model.core.AuthorizeRequest;
+import eu.chargetime.ocpp.model.core.IdTagInfo;
+import java.util.Set;
+import java.util.UUID;
+
+public class AuthorizationIdTagAdapter extends CoreEventHandlerAdapter {
+
+  private final Set<String> tags;
+
+  public AuthorizationIdTagAdapter(Set<String> tags) {
+    this.tags = tags;
+  }
+
+  @Override
+  public AuthorizeConfirmation handleAuthorizeRequest(UUID sessionIndex, AuthorizeRequest request) {
+    String tag = request.getIdTag();
+
+    if (tags.isEmpty() || tags.contains(tag)) {
+      return new AuthorizeConfirmation(new IdTagInfo(AuthorizationStatus.Accepted));
+    }
+
+    return new AuthorizeConfirmation(new IdTagInfo(AuthorizationStatus.Invalid));
+  }
+
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/BootConfigAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/BootConfigAdapter.java
@@ -1,0 +1,57 @@
+package org.connectorio.addons.binding.ocpp.internal.server.adapter;
+
+import eu.chargetime.ocpp.model.core.BootNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.BootNotificationRequest;
+import eu.chargetime.ocpp.model.core.GetConfigurationConfirmation;
+import eu.chargetime.ocpp.model.core.GetConfigurationRequest;
+import eu.chargetime.ocpp.model.core.KeyValueType;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.connectorio.addons.binding.ocpp.internal.OcppSender;
+import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
+import org.connectorio.addons.binding.ocpp.internal.server.OcppChargerConfigRegistry;
+import org.connectorio.addons.binding.ocpp.internal.server.OcppChargerSessionRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BootConfigAdapter extends CoreEventHandlerAdapter implements OcppChargerConfigRegistry {
+
+  private final Logger logger = LoggerFactory.getLogger(BootConfigAdapter.class);
+  private final Map<ChargerReference, Map<String, Object>> configMap = new ConcurrentHashMap<>();
+  private final OcppChargerSessionRegistry sessionRegistry;
+  private final OcppSender sender;
+
+  public BootConfigAdapter(OcppChargerSessionRegistry sessionRegistry, OcppSender sender) {
+    this.sessionRegistry = sessionRegistry;
+    this.sender = sender;
+  }
+
+  @Override
+  public BootNotificationConfirmation handleBootNotificationRequest(UUID sessionIndex, BootNotificationRequest request) {
+    ChargerReference reference = new ChargerReference(request.getChargePointSerialNumber());
+    if (sessionRegistry.getSession(reference) != null) {
+      sender.<GetConfigurationConfirmation>send(reference, new GetConfigurationRequest()).whenComplete((r, e) -> {
+        if (e != null) {
+          logger.warn("Could not obtain configuration for charger {}. This indicates incomplete implementation of OCPP core profile for charger.", reference, e);
+          return;
+        }
+
+        Map<String, Object> config = new LinkedHashMap<>();
+        KeyValueType[] keys = r.getConfigurationKey();
+        for (KeyValueType k : keys) {
+          config.put(k.getKey(), k.getValue());
+        }
+        configMap.put(reference, config);
+      });
+    }
+
+    return null;
+  }
+
+  @Override
+  public Map<String, Object> getConfig(ChargerReference reference) {
+    return configMap.get(reference);
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/BootRegistrationAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/BootRegistrationAdapter.java
@@ -1,0 +1,56 @@
+package org.connectorio.addons.binding.ocpp.internal.server.adapter;
+
+import eu.chargetime.ocpp.model.core.BootNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.BootNotificationRequest;
+import eu.chargetime.ocpp.model.core.RegistrationStatus;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
+import org.connectorio.addons.binding.ocpp.internal.server.OcppChargerSessionRegistry;
+
+public class BootRegistrationAdapter extends CoreEventHandlerAdapter implements
+  OcppChargerSessionRegistry {
+
+  private final Map<UUID, ChargerReference> registrations = new ConcurrentHashMap<>();
+
+  private final Set<String> identifiers;
+
+  public BootRegistrationAdapter(Set<String> identifiers) {
+    this.identifiers = identifiers;
+  }
+
+  @Override
+  public BootNotificationConfirmation handleBootNotificationRequest(UUID sessionIndex, BootNotificationRequest request) {
+    ZonedDateTime time = ZonedDateTime.now();
+    if (identifiers.isEmpty() || identifiers.contains(request.getChargePointSerialNumber())) {
+      registrations.put(sessionIndex, new ChargerReference(request.getChargePointSerialNumber()));
+      return new BootNotificationConfirmation(time, 60, RegistrationStatus.Accepted);
+    }
+
+    // keep charger connected, but not active
+    return new BootNotificationConfirmation(time, 300, RegistrationStatus.Pending);
+  }
+
+  @Override
+  public UUID getSession(ChargerReference chargerReference) {
+    for (Map.Entry<UUID, ChargerReference> entry : registrations.entrySet()) {
+      if (entry.getValue().equals(chargerReference)) {
+        return entry.getKey();
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public ChargerReference removeSession(UUID session) {
+    return registrations.remove(session);
+  }
+
+  @Override
+  public ChargerReference getCharger(UUID sessionIndex) {
+    return registrations.get(sessionIndex);
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/CoreEventHandlerAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/CoreEventHandlerAdapter.java
@@ -1,0 +1,63 @@
+package org.connectorio.addons.binding.ocpp.internal.server.adapter;
+
+import eu.chargetime.ocpp.feature.profile.ServerCoreEventHandler;
+import eu.chargetime.ocpp.model.core.AuthorizeConfirmation;
+import eu.chargetime.ocpp.model.core.AuthorizeRequest;
+import eu.chargetime.ocpp.model.core.BootNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.BootNotificationRequest;
+import eu.chargetime.ocpp.model.core.DataTransferConfirmation;
+import eu.chargetime.ocpp.model.core.DataTransferRequest;
+import eu.chargetime.ocpp.model.core.HeartbeatConfirmation;
+import eu.chargetime.ocpp.model.core.HeartbeatRequest;
+import eu.chargetime.ocpp.model.core.MeterValuesConfirmation;
+import eu.chargetime.ocpp.model.core.MeterValuesRequest;
+import eu.chargetime.ocpp.model.core.StartTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StartTransactionRequest;
+import eu.chargetime.ocpp.model.core.StatusNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
+import eu.chargetime.ocpp.model.core.StopTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StopTransactionRequest;
+import java.util.UUID;
+
+public class CoreEventHandlerAdapter implements ServerCoreEventHandler {
+
+  @Override
+  public AuthorizeConfirmation handleAuthorizeRequest(UUID sessionIndex, AuthorizeRequest request) {
+    return null;
+  }
+
+  @Override
+  public BootNotificationConfirmation handleBootNotificationRequest(UUID sessionIndex, BootNotificationRequest request) {
+    return null;
+  }
+
+  @Override
+  public DataTransferConfirmation handleDataTransferRequest(UUID sessionIndex, DataTransferRequest request) {
+    return null;
+  }
+
+  @Override
+  public HeartbeatConfirmation handleHeartbeatRequest(UUID sessionIndex, HeartbeatRequest request) {
+    return null;
+  }
+
+  @Override
+  public MeterValuesConfirmation handleMeterValuesRequest(UUID sessionIndex, MeterValuesRequest request) {
+    return null;
+  }
+
+  @Override
+  public StartTransactionConfirmation handleStartTransactionRequest(UUID sessionIndex, StartTransactionRequest request) {
+    return null;
+  }
+
+  @Override
+  public StatusNotificationConfirmation handleStatusNotificationRequest(UUID sessionIndex, StatusNotificationRequest request) {
+    return null;
+  }
+
+  @Override
+  public StopTransactionConfirmation handleStopTransactionRequest(UUID sessionIndex, StopTransactionRequest request) {
+    return null;
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/HearbeatAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/HearbeatAdapter.java
@@ -1,0 +1,15 @@
+package org.connectorio.addons.binding.ocpp.internal.server.adapter;
+
+import eu.chargetime.ocpp.model.core.HeartbeatConfirmation;
+import eu.chargetime.ocpp.model.core.HeartbeatRequest;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+public class HearbeatAdapter extends CoreEventHandlerAdapter {
+
+  @Override
+  public HeartbeatConfirmation handleHeartbeatRequest(UUID sessionIndex, HeartbeatRequest request) {
+    //System.out.println(request);
+    return new HeartbeatConfirmation(ZonedDateTime.now());
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/RequestListenerAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/RequestListenerAdapter.java
@@ -1,21 +1,4 @@
-/*
- * Copyright (C) 2022-2022 ConnectorIO Sp. z o.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-package org.connectorio.addons.binding.ocpp.internal.server;
+package org.connectorio.addons.binding.ocpp.internal.server.adapter;
 
 import eu.chargetime.ocpp.feature.profile.ServerCoreEventHandler;
 import eu.chargetime.ocpp.model.Request;
@@ -29,85 +12,68 @@ import eu.chargetime.ocpp.model.core.HeartbeatConfirmation;
 import eu.chargetime.ocpp.model.core.HeartbeatRequest;
 import eu.chargetime.ocpp.model.core.MeterValuesConfirmation;
 import eu.chargetime.ocpp.model.core.MeterValuesRequest;
-import eu.chargetime.ocpp.model.core.RegistrationStatus;
 import eu.chargetime.ocpp.model.core.StartTransactionConfirmation;
 import eu.chargetime.ocpp.model.core.StartTransactionRequest;
 import eu.chargetime.ocpp.model.core.StatusNotificationConfirmation;
 import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
 import eu.chargetime.ocpp.model.core.StopTransactionConfirmation;
 import eu.chargetime.ocpp.model.core.StopTransactionRequest;
-import java.time.ZonedDateTime;
-import java.util.Set;
 import java.util.UUID;
 import org.connectorio.addons.binding.ocpp.internal.OcppRequestListener;
-import org.connectorio.addons.binding.ocpp.internal.OcppSender;
-import org.eclipse.jetty.client.api.Request.RequestListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-public class OcppServerCoreEventHandler implements ServerCoreEventHandler {
 
-  private final Logger logger = LoggerFactory.getLogger(OcppServerCoreEventHandler.class);
-  private OcppSender sender;
-  private OcppRequestListener<Request> listener;
-  private final Set<String> identifiers;
-  private final Set<String> tags;
+public class RequestListenerAdapter implements ServerCoreEventHandler {
 
-  public OcppServerCoreEventHandler(OcppSender sender, OcppRequestListener<Request> listener, Set<String> identifiers, Set<String> tags) {
-    this.sender = sender;
+  private final OcppRequestListener<Request> listener;
+
+  public RequestListenerAdapter(OcppRequestListener<Request> listener) {
     this.listener = listener;
-    this.identifiers = identifiers;
-    this.tags = tags;
   }
 
   @Override
   public AuthorizeConfirmation handleAuthorizeRequest(UUID sessionIndex, AuthorizeRequest request) {
-    request.getIdTag();
+    listener.onRequest(request);
     return null;
   }
 
   @Override
   public BootNotificationConfirmation handleBootNotificationRequest(UUID sessionIndex, BootNotificationRequest request) {
-    if (identifiers.isEmpty()) {
-      listener.onRequest(request);
-      return new BootNotificationConfirmation(ZonedDateTime.now(), 1000, RegistrationStatus.Accepted);
-    }
-    if (identifiers.contains(request.getMeterSerialNumber())) {
-      listener.onRequest(request);
-      return new BootNotificationConfirmation(ZonedDateTime.now(), 1000, RegistrationStatus.Accepted);
-    }
-
-    // skip notifying listeners
-    return new BootNotificationConfirmation(ZonedDateTime.now(), 1000, RegistrationStatus.Rejected);
+    listener.onRequest(request);
+    return null;
   }
 
   @Override
   public DataTransferConfirmation handleDataTransferRequest(UUID sessionIndex, DataTransferRequest request) {
+    listener.onRequest(request);
     return null;
   }
 
   @Override
   public HeartbeatConfirmation handleHeartbeatRequest(UUID sessionIndex, HeartbeatRequest request) {
-    return new HeartbeatConfirmation(ZonedDateTime.now());
+    listener.onRequest(request);
+    return null;
   }
 
   @Override
   public MeterValuesConfirmation handleMeterValuesRequest(UUID sessionIndex, MeterValuesRequest request) {
-    logger.info("Received meter values for session {}: {}", sessionIndex, request);
-    return new MeterValuesConfirmation();
+    listener.onRequest(request);
+    return null;
   }
 
   @Override
   public StartTransactionConfirmation handleStartTransactionRequest(UUID sessionIndex, StartTransactionRequest request) {
+    listener.onRequest(request);
     return null;
   }
 
   @Override
   public StatusNotificationConfirmation handleStatusNotificationRequest(UUID sessionIndex, StatusNotificationRequest request) {
-    return new StatusNotificationConfirmation();
+    listener.onRequest(request);
+    return null;
   }
 
   @Override
   public StopTransactionConfirmation handleStopTransactionRequest(UUID sessionIndex, StopTransactionRequest request) {
+    listener.onRequest(request);
     return null;
   }
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/StatusAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/StatusAdapter.java
@@ -1,0 +1,17 @@
+package org.connectorio.addons.binding.ocpp.internal.server.adapter;
+
+import eu.chargetime.ocpp.model.core.StatusNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
+import java.util.UUID;
+
+public class StatusAdapter extends CoreEventHandlerAdapter {
+
+  @Override
+  public StatusNotificationConfirmation handleStatusNotificationRequest(UUID sessionIndex, StatusNotificationRequest request) {
+    // return super.handleStatusNotificationRequest(sessionIndex, request);
+
+    System.out.println("Status " + request);
+
+    return new StatusNotificationConfirmation();
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/TransactionAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/TransactionAdapter.java
@@ -1,0 +1,24 @@
+package org.connectorio.addons.binding.ocpp.internal.server.adapter;
+
+import eu.chargetime.ocpp.model.core.StartTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StartTransactionRequest;
+import eu.chargetime.ocpp.model.core.StopTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StopTransactionRequest;
+import java.util.UUID;
+
+public class TransactionAdapter extends CoreEventHandlerAdapter {
+
+  @Override
+  public StartTransactionConfirmation handleStartTransactionRequest(UUID sessionIndex, StartTransactionRequest request) {
+    // return super.handleStartTransactionRequest(sessionIndex, request);
+    System.out.println("Start transaction " + request);
+    return new StartTransactionConfirmation();
+  }
+
+  @Override
+  public StopTransactionConfirmation handleStopTransactionRequest(UUID sessionIndex, StopTransactionRequest request) {
+    //return super.handleStopTransactionRequest(sessionIndex, request);
+    System.out.println("Stop transaction " + request);
+    return new StopTransactionConfirmation();
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/listener/HeartbeatHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/listener/HeartbeatHandler.java
@@ -1,0 +1,10 @@
+package org.connectorio.addons.binding.ocpp.internal.server.listener;
+
+import eu.chargetime.ocpp.model.core.HeartbeatConfirmation;
+import eu.chargetime.ocpp.model.core.HeartbeatRequest;
+
+public interface HeartbeatHandler {
+
+  HeartbeatConfirmation handleHeartbeat(HeartbeatRequest request);
+
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/listener/MeterValuesHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/listener/MeterValuesHandler.java
@@ -1,0 +1,10 @@
+package org.connectorio.addons.binding.ocpp.internal.server.listener;
+
+import eu.chargetime.ocpp.model.core.MeterValuesConfirmation;
+import eu.chargetime.ocpp.model.core.MeterValuesRequest;
+
+public interface MeterValuesHandler {
+
+  MeterValuesConfirmation handleMeterValues(MeterValuesRequest request);
+
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/listener/StatusNotificationHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/listener/StatusNotificationHandler.java
@@ -1,0 +1,10 @@
+package org.connectorio.addons.binding.ocpp.internal.server.listener;
+
+import eu.chargetime.ocpp.model.core.StatusNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
+
+public interface StatusNotificationHandler {
+
+  StatusNotificationConfirmation handleStatusNotification(StatusNotificationRequest request);
+
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/listener/TransactionHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/listener/TransactionHandler.java
@@ -1,0 +1,13 @@
+package org.connectorio.addons.binding.ocpp.internal.server.listener;
+
+import eu.chargetime.ocpp.model.core.StartTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StartTransactionRequest;
+import eu.chargetime.ocpp.model.core.StopTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StopTransactionRequest;
+
+public interface TransactionHandler {
+
+  StartTransactionConfirmation handleStartTransaction(StartTransactionRequest request);
+  StopTransactionConfirmation handleStopTransaction(StopTransactionRequest request);
+
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/channels.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ - Copyright (C) 2024-2024 ConnectorIO sp. z o.o.
+ -
+ - This is free software; you can redistribute it and/or modify
+ - it under the terms of the GNU General Public License as published by
+ - the Free Software Foundation; either version 2 of the License, or
+ - (at your option) any later version.
+ -
+ -     https://www.gnu.org/licenses/gpl-3.0.txt
+ -
+ - This library is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU General Public License for more details.
+ -
+ - You should have received a copy of the GNU General Public License
+ - along with Foobar; if not, write to the Free Software
+ - Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ -
+ - SPDX-License-Identifier: GPL-3.0-or-later
+-->
+<thing:thing-descriptions bindingId="co7io-ocpp"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+  xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+  <!-- basics -->
+  <channel-type id="dateTime">
+    <item-type>DateTime</item-type>
+    <label>Date time value</label>
+    <description>Date time value.</description>
+  </channel-type>
+
+  <channel-type id="number">
+    <item-type>Number</item-type>
+    <label>Number value</label>
+    <description>Number value.</description>
+  </channel-type>
+
+  <channel-type id="string">
+    <item-type>String</item-type>
+    <label>String value</label>
+    <description>String value.</description>
+  </channel-type>
+
+  <!-- quantities -->
+  <channel-type id="current">
+    <item-type>Number:ElectricCurrent</item-type>
+    <label>Current</label>
+    <description>Electric current value.</description>
+  </channel-type>
+
+  <channel-type id="energy">
+    <item-type>Number:Energy</item-type>
+    <label>Energy</label>
+    <description>Energy.</description>
+  </channel-type>
+
+  <channel-type id="frequency">
+    <item-type>Number:Frequency</item-type>
+    <label>Frequency</label>
+    <description>Frequency.</description>
+  </channel-type>
+
+  <channel-type id="percent">
+    <item-type>Dimmer</item-type>
+    <label>Percentage</label>
+  </channel-type>
+
+  <channel-type id="power">
+    <item-type>Number:Power</item-type>
+    <label>Power</label>
+    <description>Power.</description>
+  </channel-type>
+
+  <channel-type id="temperature">
+    <item-type>Number:Temperature</item-type>
+    <label>Temperature</label>
+    <description>Temperature.</description>
+  </channel-type>
+
+  <channel-type id="voltage">
+    <item-type>Number:ElectricPotential</item-type>
+    <label>Voltage</label>
+    <description>Electric voltage value.</description>
+  </channel-type>
+
+  <!-- enumerations -->
+  <channel-type id="chargePointStatus">
+    <item-type>String</item-type>
+    <label>Charge point status</label>
+    <state>
+      <options>
+        <option value="Available">Available</option>
+        <option value="Preparing">Preparing</option>
+        <option value="Charging">Charging</option>
+        <option value="SuspendedEVSE">SuspendedEVSE</option>
+        <option value="SuspendedEV">SuspendedEV</option>
+        <option value="Finishing">Finishing</option>
+        <option value="Reserved">Reserved</option>
+        <option value="Unavailable">Unavailable</option>
+        <option value="Faulted">Faulted</option>
+      </options>
+    </state>
+  </channel-type>
+
+</thing:thing-descriptions>

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -62,7 +62,7 @@
     </config-description>
   </bridge-type>
 
-  <thing-type id="charger">
+  <bridge-type id="charger">
     <supported-bridge-type-refs>
       <bridge-type-ref id="server"/>
     </supported-bridge-type-refs>
@@ -71,6 +71,10 @@
     <description>An instance of electric charger.</description>
 
     <config-description>
+      <parameter name="serialNumber" type="text" required="true">
+        <label>Charge point serial number</label>
+        <description>Serial number of charge point (defined by manufacturer).</description>
+      </parameter>
       <parameter name="heartbeat" type="integer" required="false" min="1">
         <label>Heartbeat</label>
         <description>
@@ -80,7 +84,7 @@
         <unitLabel>s</unitLabel>
       </parameter>
     </config-description>
-  </thing-type>
+  </bridge-type>
 
   <thing-type id="connector">
     <supported-bridge-type-refs>
@@ -89,6 +93,134 @@
 
     <label>Connector</label>
     <description>A charger connector.</description>
+
+    <channels>
+      <channel id="chargePointStatus" typeId="chargePointStatus" />
+      <channel id="transactionId" typeId="number">
+        <label>Transaction id</label>
+        <description>Current transaction.</description>
+      </channel>
+      <channel id="idTag" typeId="string">
+        <label>Tag</label>
+        <description>Tag identifier.</description>
+      </channel>
+      <channel id="timestampStart" typeId="dateTime">
+        <label>Start timestamp</label>
+        <description>Start timestamp of most recent transaction.</description>
+      </channel>
+      <channel id="timestampStop" typeId="dateTime">
+        <label>Stop timestamp</label>
+        <description>Stop timestamp of most recent transaction.</description>
+      </channel>
+      <channel id="meterStart" typeId="energy">
+        <label>Meter start</label>
+        <description>Value of meter energy reading at the start of transaction.</description>
+      </channel>
+      <channel id="meterStop" typeId="energy">
+        <label>Meter stop</label>
+        <description>Value of meter energy reading at the end of transaction.</description>
+      </channel>
+
+      <channel id="timestamp" typeId="dateTime">
+        <label>Timestamp of samples being pushed to measurement channels.</label>
+      </channel>
+      <channel id="currentExport" typeId="current">
+        <label>Current.Export</label>
+        <description>Instantaneous current flow from EV</description>
+      </channel>
+      <channel id="currentImport" typeId="current">
+        <label>Current.Import</label>
+        <description>Instantaneous current flow to EV</description>
+      </channel>
+      <channel id="currentOffered" typeId="current">
+        <label>Current.Offered</label>
+        <description>Maximum current offered to EV</description>
+      </channel>
+      <channel id="energyActiveExport" typeId="energy">
+        <label>Energy.Active.Export.Register</label>
+        <description>Energy exported by EV (Wh or kWh)</description>
+      </channel>
+      <channel id="energyActiveImport" typeId="energy">
+        <label>Energy.Active.Import.Register</label>
+        <description>Energy imported by EV (Wh or kWh)</description>
+      </channel>
+      <channel id="energyReactiveExport" typeId="energy">
+        <label>Energy.Reactive.Export.Register</label>
+        <description>Reactive energy exported by EV (varh or kvarh)</description>
+      </channel>
+      <channel id="energyReactiveImport" typeId="energy">
+        <label>Energy.Reactive.Import.Register</label>
+        <description>Reactive energy imported by EV (varh or kvarh)</description>
+      </channel>
+      <channel id="energyActiveExportInterval" typeId="energy">
+        <label>Energy.Active.Export.Interval</label>
+        <description>Energy exported by EV (Wh or kWh)</description>
+      </channel>
+      <channel id="energyActiveImportInterval" typeId="energy">
+        <label>Energy.Active.Import.Interval</label>
+        <description>Energy imported by EV (Wh or kWh)</description>
+      </channel>
+      <channel id="energyReactiveExportInterval" typeId="energy">
+        <label>Energy.Reactive.Export.Interval</label>
+        <description>Reactive energy exported by EV. (varh or kvarh)</description>
+      </channel>
+      <channel id="energyReactiveImportInterval" typeId="energy">
+        <label>Energy.Reactive.Import.Interval</label>
+        <description>Reactive energy imported by EV. (varh or kvarh)</description>
+      </channel>
+      <channel id="frequency" typeId="frequency">
+        <label>Frequency</label>
+        <description>Instantaneous reading of powerline frequency</description>
+      </channel>
+      <channel id="powerActiveExport" typeId="power">
+        <label>Power.Active.Export</label>
+        <description>Instantaneous active power exported by EV. (W or kW)</description>
+      </channel>
+      <channel id="powerActiveImport" typeId="power">
+        <label>Power.Active.Import</label>
+        <description>Instantaneous active power imported by EV. (W or kW)</description>
+      </channel>
+      <channel id="powerFactor" typeId="number">
+        <label>Power.Factor</label>
+        <description>Instantaneous power factor of total energy flow</description>
+      </channel>
+      <channel id="powerOffered" typeId="power">
+        <label>Power.Offered</label>
+        <description>Maximum power offered to EV</description>
+      </channel>
+      <channel id="powerReactiveExport" typeId="power">
+        <label>Power.Reactive.Export</label>
+        <description>Instantaneous reactive power exported by EV. (var or kvar)</description>
+      </channel>
+      <channel id="powerReactiveImport" typeId="power">
+        <label>Power.Reactive.Import</label>
+        <description>Instantaneous reactive power imported by EV. (var or kvar)</description>
+      </channel>
+      <channel id="rpm" typeId="number">
+        <label>RPM</label>
+        <description>Fan speed in RPM</description>
+      </channel>
+      <channel id="soc" typeId="percent">
+        <label>SoC</label>
+        <description>State of charge of charging vehicle in percentage.</description>
+      </channel>
+      <channel id="temperature" typeId="temperature">
+        <label>Temperature</label>
+        <description>Temperature reading inside Charge Point.</description>
+      </channel>
+      <channel id="voltage" typeId="voltage">
+        <label>Voltage</label>
+        <description>Instantaneous AC RMS supply voltage</description>
+      </channel>
+    </channels>
+
+    <config-description>
+      <parameter name="connectorId" type="integer" required="true" min="1" step="1">
+        <label>Connector</label>
+        <description>Identifier of connector - starts from 1.</description>
+      </parameter>
+    </config-description>
+
   </thing-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
This is first version of working (let say) of OCPP binding for openHAB. It supports discovery but also sourcing of charger/charging state through meter values.

Note: code still work only in read-only fashion of OCPP core profile. It does not support (yet) writing or smart charging profile.

![OCPP binding elements](https://github.com/user-attachments/assets/51788f13-3a2f-4418-b78e-f7ba8003a84f)

![Items populated through OCPP binding](https://github.com/user-attachments/assets/90dae739-d3e1-4c3b-baa6-df7a59b5552a)
