### PR TITLE
More robust ocpp connection

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppChargerSessionRegistry.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppChargerSessionRegistry.java
@@ -3,6 +3,8 @@ package org.connectorio.addons.binding.ocpp.internal.server;
 import java.util.UUID;
 
 public interface OcppChargerSessionRegistry {
+	
+  void registerSession(UUID session, ChargerReference chargerReference);
 
   UUID getSession(ChargerReference chargerReference);
 

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppServer.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppServer.java
@@ -68,6 +68,16 @@ public class OcppServer implements OcppSender {
       @Override
       public void newSession(UUID sessionIndex, SessionInformation information) {
         logger.info("New OCPP connection {} with identifier {} from address {}.", sessionIndex, information.getIdentifier(), information.getAddress());
+
+        // Register session immediately on connect, don't wait for BootNotification
+        // as some chargers sends the BootNotification only if the charger is rebooted.
+        String identifier = information.getIdentifier();
+        if (identifier != null && identifier.startsWith("/")) {
+            identifier = identifier.substring(1);
+        }
+        
+        chargerSessionRegistry.registerSession(sessionIndex, 
+            new ChargerReference(identifier));
       }
 
       @Override

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/BootRegistrationAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/BootRegistrationAdapter.java
@@ -21,13 +21,20 @@ public class BootRegistrationAdapter extends CoreEventHandlerAdapter implements
   public BootRegistrationAdapter(Set<String> identifiers) {
     this.identifiers = identifiers;
   }
+  
+  @Override
+  public void registerSession(UUID session, ChargerReference chargerReference) {
+      registrations.put(session, chargerReference);
+  }
 
   @Override
   public BootNotificationConfirmation handleBootNotificationRequest(UUID sessionIndex, BootNotificationRequest request) {
     ZonedDateTime time = ZonedDateTime.now();
-    if (identifiers.isEmpty() || identifiers.contains(request.getChargePointSerialNumber())) {
-      registrations.put(sessionIndex, new ChargerReference(request.getChargePointSerialNumber()));
-      return new BootNotificationConfirmation(time, 60, RegistrationStatus.Accepted);
+    // Session already registered in newSession()
+    
+    ChargerReference registered = registrations.get(sessionIndex);
+    if (identifiers.isEmpty() || (registered != null && identifiers.contains(registered.getSerial()))) {
+    	return new BootNotificationConfirmation(time, 60, RegistrationStatus.Accepted);
     }
 
     // keep charger connected, but not active

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -73,7 +73,7 @@
     <config-description>
       <parameter name="serialNumber" type="text" required="true">
         <label>Charge point serial number</label>
-        <description>Serial number of charge point (defined by manufacturer).</description>
+        <description>OCPP identify of the charge point (WebSocket URL path).</description>
       </parameter>
       <parameter name="heartbeat" type="integer" required="false" min="1">
         <label>Heartbeat</label>


### PR DESCRIPTION
- Change from `chargerPointSerialNumber` to `serial` which is OCPP Identity
  - The [spec](https://openchargealliance.org/my-oca/ocpp/) describes the connection URL in file `ocpp-j-1.6-specification.pdf` in 3.1.1. The spec file `ocpp-1.6 edition 2.pdf` describes the BootNotification request parameter `chargePointSerialNumber` as `Optional`. For these reasons, I feel we should use `serial` (OCPP Identify).
- Register charger in `newSession()` as some chargers like the Ocular IQ Home Solar only sends the BootNotification message when the charger restarts.