### PR TITLE
[ocpp] Surface dangling-future failures via .orTimeout()

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppServer.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppServer.java
@@ -32,12 +32,24 @@ import java.util.Deque;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.connectorio.addons.binding.ocpp.internal.OcppSender;
 import org.connectorio.addons.binding.ocpp.internal.server.custom.OcularSolarEcoMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class OcppServer implements OcppSender {
+
+  /**
+   * Maximum time to wait for a charger to answer a CSMS-initiated CALL.
+   * chargetime/ocpp's {@code Server.send(...)} returns a future from
+   * {@code PromiseRepository} that is silently orphaned when the underlying
+   * WebSocket closes mid-flight — see ChargeTimeEU/Java-OCA-OCPP#121. Wrapping
+   * with {@code orTimeout} surfaces the failure as a
+   * {@link TimeoutException} instead of leaving the caller waiting forever.
+   */
+  private static final long CALL_TIMEOUT_SECONDS = 15;
 
   private final Logger logger = LoggerFactory.getLogger(OcppServer.class);
   private final JSONServer server;
@@ -97,7 +109,16 @@ public class OcppServer implements OcppSender {
         logger.warn("Could not send request {} to charger {}. Session not found.", request, chargerReference);
         return CompletableFuture.failedFuture(new NotConnectedException());
       }
-      return this.server.send(sessionIndex, request);
+      return this.server.send(sessionIndex, request)
+          .toCompletableFuture()
+          .orTimeout(CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+          .whenComplete((confirmation, throwable) -> {
+            if (throwable instanceof TimeoutException) {
+              logger.warn("Request {} to charger {} timed out after {} s — chargetime/ocpp future may have been"
+                      + " orphaned by socket close (ChargeTimeEU/Java-OCA-OCPP#121).",
+                  request.getClass().getSimpleName(), chargerReference, CALL_TIMEOUT_SECONDS);
+            }
+          });
     } catch (OccurenceConstraintException | UnsupportedFeatureException | NotConnectedException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
## Summary

Wraps every outbound CALL from `OcppServer.send(...)` with `.orTimeout(15s)` so dangling futures surface as a logged `TimeoutException` instead of silence.

## Why

chargetime/ocpp's `Server.send(UUID, Request)` returns a future from `PromiseRepository`. When the underlying WebSocket closes mid-flight (which happens with imperfect charger firmwares — Wallbox idle timeout, network partition, etc.), the future is silently orphaned and never completed. See [ChargeTimeEU/Java-OCA-OCPP#121](https://github.com/ChargeTimeEU/Java-OCA-OCPP/issues/121).

Symptoms in practice:
- Operator sends a `SetChargingProfile` or `UnlockConnector`
- Log shows the CALL being sent
- Caller's `.whenComplete(confirmation, throwable)` **never fires** — neither success nor failure path
- Operator sees no follow-up at all, indistinguishable from "command sent and accepted"

This was the root cause of several confusing debugging sessions on real Wallbox chargers — `ChargeProfile` requests would complete (status `Accepted`) most of the time but ~10% of the time produce zero feedback because the socket had been cycled in the meantime.

## What changes

Single-file change to `OcppServer.send(...)`:

```java
return this.server.send(sessionIndex, request)
    .toCompletableFuture()
    .orTimeout(CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
    .whenComplete((confirmation, throwable) -> {
      if (throwable instanceof TimeoutException) {
        logger.warn("Request {} to charger {} timed out after {} s — ...",
            request.getClass().getSimpleName(), chargerReference, CALL_TIMEOUT_SECONDS);
      }
    });
```

- `CALL_TIMEOUT_SECONDS = 15` as a private constant (sensible default; could be made a thing parameter in a follow-up if needed)
- Added imports for `TimeUnit` and `TimeoutException`
- `.whenComplete` at the server layer logs *just* the timeout case at WARN; other exceptions still propagate to the caller's existing `.whenComplete` error handlers (e.g. `ConnectorThingHandler.sendChangeConfiguration`) which already log them

## Backwards compatibility

- Successful CALLs unchanged — caller sees the same `Confirmation` it always did
- Caller-observed exceptions are unchanged for non-timeout cases
- For timeouts, callers now see `TimeoutException` instead of waiting forever. Their existing `.whenComplete((c, t) -> { if (t != null) logger.warn(...) })` blocks throughout the codebase pick this up automatically and log "Failed to ... : TimeoutException" — strictly better than silence.

## Test plan

- [x] Diff is syntactically clean against the 5.0.x branch
- [x] Verified end-to-end on two Wallbox chargers in a separate openHAB-flavored binding that uses the same chargetime/ocpp library — same pattern: timeouts now surface as logged warnings, callers' error handlers fire, no more silent dangling futures
- [ ] Reviewer feedback welcome on whether 15 s is the right default and whether it should be a thing parameter on the server bridge

## Refs

- Tracking issue: #131
- Upstream library bug: [ChargeTimeEU/Java-OCA-OCPP#121](https://github.com/ChargeTimeEU/Java-OCA-OCPP/issues/121)

---

*Disclosure: code and writeup produced with Anthropic Claude (Claude Code) assistance; reviewed, signed off, and tested against real chargers by @stamateviorel.*
