### PR TITLE
[ocpp] Add diagnostic GetConfiguration dump on BootNotification

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ServerBridgeHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ServerBridgeHandler.java
@@ -41,6 +41,7 @@ import org.connectorio.addons.binding.ocpp.internal.server.CompositeRequestListe
 import org.connectorio.addons.binding.ocpp.internal.server.OcppServer;
 import org.connectorio.addons.binding.ocpp.internal.server.adapter.AuthorizationIdTagAdapter;
 import org.connectorio.addons.binding.ocpp.internal.server.adapter.BootRegistrationAdapter;
+import org.connectorio.addons.binding.ocpp.internal.server.adapter.OcppConfigurationDumpAdapter;
 import org.connectorio.addons.binding.ocpp.internal.server.adapter.RequestListenerAdapter;
 import org.connectorio.addons.binding.ocpp.internal.server.custom.OcularSolarEcoMode;
 import org.openhab.core.net.NetworkAddressService;
@@ -102,6 +103,14 @@ public class ServerBridgeHandler extends GenericBridgeHandlerBase<ServerConfig> 
       address, config.port, bootAdapter, eventHandlers,
       new OcularSolarEcoMode(config.initialOcularEcoMode)
     );
+
+    // Diagnostic dump of every charger's configuration on Boot. Listener-only;
+    // returns null so it never affects the chain's BootNotificationConfirmation.
+    // Added to the (thread-safe) deque after server construction so it can hold
+    // the OcppSender reference, and before activate() so it's wired up before
+    // the first session opens.
+    eventHandlers.add(new OcppConfigurationDumpAdapter(server, bootAdapter));
+
     server.activate();
     updateStatus(ThingStatus.ONLINE);
   }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/OcppConfigurationDumpAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/OcppConfigurationDumpAdapter.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2022-2026 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.binding.ocpp.internal.server.adapter;
+
+import eu.chargetime.ocpp.model.core.BootNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.BootNotificationRequest;
+import eu.chargetime.ocpp.model.core.GetConfigurationConfirmation;
+import eu.chargetime.ocpp.model.core.GetConfigurationRequest;
+import eu.chargetime.ocpp.model.core.KeyValueType;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.connectorio.addons.binding.ocpp.internal.OcppSender;
+import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
+import org.connectorio.addons.binding.ocpp.internal.server.OcppChargerSessionRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Side-effect-only event handler that, on every {@code BootNotification},
+ * fires a one-shot {@code GetConfiguration} (no key list = "all keys") to
+ * the charger and logs each returned key/value/readonly at {@code INFO}.
+ *
+ * <p>Returns {@code null} from all event handler methods, so it never
+ * influences the chain's {@code Confirmation} (the active responder remains
+ * {@link BootRegistrationAdapter}).
+ *
+ * <p>This is a diagnostic helper. It makes vendor-specific configuration
+ * keys (e.g. Wallbox's {@code chargingALimitConn1}, Alfen's
+ * {@code OperativeMaxCurrent}, KEBA's {@code MaxCurrentInternalLimit}) plus
+ * the standard OCPP keys (e.g. {@code MeterValueSampleInterval},
+ * {@code MeterValuesSampledData}, {@code WebSocketPingInterval}) visible in
+ * the openHAB log without having to attach a separate OCPP debugger.
+ */
+public class OcppConfigurationDumpAdapter extends CoreEventHandlerAdapter {
+
+  /**
+   * Delay before firing {@code GetConfiguration}. Lets the
+   * {@code BootNotificationConfirmation} reach the charger first so the
+   * charger has fully transitioned to "registered" state before we ask
+   * follow-up questions.
+   */
+  private static final long DUMP_DELAY_SECONDS = 2;
+
+  private final Logger logger = LoggerFactory.getLogger(OcppConfigurationDumpAdapter.class);
+  private final OcppSender sender;
+  private final OcppChargerSessionRegistry registry;
+
+  public OcppConfigurationDumpAdapter(OcppSender sender, OcppChargerSessionRegistry registry) {
+    this.sender = sender;
+    this.registry = registry;
+  }
+
+  @Override
+  public BootNotificationConfirmation handleBootNotificationRequest(UUID sessionIndex,
+      BootNotificationRequest request) {
+    ChargerReference charger = registry.getCharger(sessionIndex);
+    if (charger == null) {
+      // Boot before registration; nothing to dump.
+      return null;
+    }
+    CompletableFuture.runAsync(() -> dump(charger),
+        CompletableFuture.delayedExecutor(DUMP_DELAY_SECONDS, TimeUnit.SECONDS));
+    return null;
+  }
+
+  private void dump(ChargerReference charger) {
+    try {
+      sender.send(charger, new GetConfigurationRequest())
+          .whenComplete((confirmation, throwable) -> {
+            if (throwable != null) {
+              logger.debug("GetConfiguration dump for {} failed: {}", charger, throwable.toString());
+              return;
+            }
+            if (!(confirmation instanceof GetConfigurationConfirmation)) {
+              return;
+            }
+            GetConfigurationConfirmation conf = (GetConfigurationConfirmation) confirmation;
+            KeyValueType[] keys = conf.getConfigurationKey();
+            if (keys != null) {
+              for (KeyValueType kv : keys) {
+                logger.info("GetConfiguration[{}]: {} = {} (readonly={})",
+                    charger, kv.getKey(), kv.getValue(), kv.getReadonly());
+              }
+            }
+            String[] unknown = conf.getUnknownKey();
+            if (unknown != null && unknown.length > 0) {
+              logger.info("GetConfiguration[{}] unknown keys: {}", charger, String.join(",", unknown));
+            }
+          });
+    } catch (Exception e) {
+      logger.debug("Could not send GetConfiguration to {}: {}", charger, e.toString());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a one-shot `GetConfiguration` (no key list = "all keys") fired automatically a couple of seconds after every `BootNotification`. Each returned key/value/readonly is logged at `INFO`. Purely diagnostic — no behavior change, no new channels, no thing parameters.

## Why

Debugging vendor-specific OCPP configuration today means either attaching a separate OCPP debugger or hand-crafting a CALL from a script. Both take real effort. A passive dump on boot makes the charger's *real* configuration visible in `openhab.log` immediately, including:

- Standard OCPP 1.6 keys (`MeterValueSampleInterval`, `MeterValuesSampledData`, `HeartbeatInterval`, `WebSocketPingInterval`, …)
- The set of `SupportedFeatureProfiles` the firmware actually implements
- Vendor extensions like Wallbox's `chargingALimitConn1` (persisted hardware max current) or `WebSocketPassword`
- Whether `UnlockConnectorOnEVSideDisconnect`, `StopTransactionOnEVSideDisconnect`, `LocalAuthListEnabled`, etc. are actually set

Live sample from a real Wallbox Copper SB on firmware 6.7.38:

```
GetConfiguration[Charger [SN: car3]]: NumberOfConnectors = 1 (readonly=true)
GetConfiguration[Charger [SN: car3]]: SupportedFeatureProfiles = Core,FirmwareManagement,LocalAuthListManagement,Reservation,SmartCharging,RemoteTrigger (readonly=true)
GetConfiguration[Charger [SN: car3]]: ChargeProfileMaxStackLevel = 10 (readonly=true)
GetConfiguration[Charger [SN: car3]]: WebSocketPingInterval = 50 (readonly=false)
GetConfiguration[Charger [SN: car3]]: chargingALimitConn1 = 32 (readonly=false)
GetConfiguration[Charger [SN: car3]]: MeterValuesAlignedData = Energy.Active.Import.Register,... (readonly=false)
... ~30 more keys ...
```

That visibility is what made it possible to find the vendor `chargingALimitConn1` key (PR 7 follow-up) and discover Wallbox's actual measurand emission style (PR 3 follow-up).

## What changes

- **New** `OcppConfigurationDumpAdapter` extends `CoreEventHandlerAdapter`.
  - On `handleBootNotificationRequest`: looks up the `ChargerReference` from the registry, schedules a `GetConfiguration` send 2 s later (lets the Boot ACK reach the charger first), logs every `KeyValueType` returned.
  - Returns `null` from all event handler methods — never influences the chain's responses. `BootRegistrationAdapter` remains the active responder.
- **`ServerBridgeHandler.initialize()`**: adds the new adapter to the (already thread-safe `ConcurrentLinkedDeque`) `eventHandlers` *after* constructing `OcppServer` (so it can hold the `OcppSender` reference) but *before* `server.activate()`.

## Backwards compatibility

- Listener-only; returns `null` from all handler methods → no observable protocol change for chargers.
- One extra outbound `GetConfiguration` per boot. OCPP 1.6 chargers are required to support this CALL (it's in the Core profile), so no risk of `UnsupportedFeatureException`.
- Log volume: ~30-50 `INFO` lines per charger boot. If anyone wants this at `DEBUG` instead I'm happy to lower it.

## Test plan

- [x] Diff syntactically clean against `5.0.x`
- [x] Verified end-to-end against two production Wallbox chargers — boot fires GetConfiguration ~2s after BootNotification accepted, log entries land as shown above
- [ ] Reviewer feedback welcome on:
  - Should this be opt-in (a thing parameter on the server bridge) rather than always-on?
  - Should the log level be `INFO` or `DEBUG`?

## Refs

- Tracking issue: #131

---

*Disclosure: code and writeup produced with Anthropic Claude (Claude Code) assistance; reviewed, signed off, and tested against real chargers by @stamateviorel.*
