### PR TITLE
[ocpp] Per-phase MeterValues parsing for 3-phase chargers

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/OcppBindingConstants.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/OcppBindingConstants.java
@@ -44,6 +44,9 @@ public interface OcppBindingConstants extends BaseBindingConstants {
   // common channel types
   ChannelRef CURRENT_EXPORT = new ChannelRef("currentExport");
   ChannelRef CURRENT_IMPORT = new ChannelRef("currentImport");
+  ChannelRef CURRENT_IMPORT_L1 = new ChannelRef("currentImportL1");
+  ChannelRef CURRENT_IMPORT_L2 = new ChannelRef("currentImportL2");
+  ChannelRef CURRENT_IMPORT_L3 = new ChannelRef("currentImportL3");
   ChannelRef CURRENT_OFFERED = new ChannelRef("currentOffered");
   ChannelRef CHARGE_LIMIT = new ChannelRef("chargeLimit");
   ChannelRef CHARGING = new ChannelRef("charging");
@@ -66,6 +69,9 @@ public interface OcppBindingConstants extends BaseBindingConstants {
   ChannelRef SOC = new ChannelRef("soc");
   ChannelRef TEMPERATURE = new ChannelRef("temperature");
   ChannelRef VOLTAGE = new ChannelRef("voltage");
+  ChannelRef VOLTAGE_L1 = new ChannelRef("voltageL1");
+  ChannelRef VOLTAGE_L2 = new ChannelRef("voltageL2");
+  ChannelRef VOLTAGE_L3 = new ChannelRef("voltageL3");
 
   static class ChannelRef extends UID {
 

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -146,11 +146,25 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
 
         try {
           Double measurement = Double.valueOf(sample.getValue());
+          // Aggregate channel (existing single-value behaviour) — kept so any
+          // pre-existing item link on currentImport / voltage / etc. continues
+          // to receive updates regardless of phase.
           UID ref = OcppMeasurementMapping.get(sample.getMeasurand());
           if (ref != null) {
             ChannelUID uid = new ChannelUID(getThing().getUID(), ref.getAsString());
             State state = parse(measurement, uid, sample);
             getCallback().stateUpdated(uid, state);
+          }
+          // Per-phase channel (currentImportL1/L2/L3, voltageL1/L2/L3) — Pete's
+          // Option 1 for 3-phase chargers. Resolves the phase from either the
+          // SampledValue.phase field or the vendor-specific measurand suffix
+          // (Wallbox FW 6.7.x emits "Current.Import.L1" without a phase field).
+          UID perPhaseRef = OcppMeasurementMapping.getPerPhase(
+              sample.getMeasurand(), sample.getPhase());
+          if (perPhaseRef != null) {
+            ChannelUID perPhaseUid = new ChannelUID(getThing().getUID(), perPhaseRef.getAsString());
+            State perPhaseState = parse(measurement, perPhaseUid, sample);
+            getCallback().stateUpdated(perPhaseUid, perPhaseState);
           }
         } catch (NumberFormatException e) {
           logger.debug("Could not parse value of measurement {}", sample, e);

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -146,25 +146,10 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
 
         try {
           Double measurement = Double.valueOf(sample.getValue());
-          // Aggregate channel (existing single-value behaviour) — kept so any
-          // pre-existing item link on currentImport / voltage / etc. continues
-          // to receive updates regardless of phase.
-          UID ref = OcppMeasurementMapping.get(sample.getMeasurand());
-          if (ref != null) {
+          for (UID ref : OcppMeasurementMapping.channelsFor(sample)) {
             ChannelUID uid = new ChannelUID(getThing().getUID(), ref.getAsString());
             State state = parse(measurement, uid, sample);
             getCallback().stateUpdated(uid, state);
-          }
-          // Per-phase channel (currentImportL1/L2/L3, voltageL1/L2/L3) — Pete's
-          // Option 1 for 3-phase chargers. Resolves the phase from either the
-          // SampledValue.phase field or the vendor-specific measurand suffix
-          // (Wallbox FW 6.7.x emits "Current.Import.L1" without a phase field).
-          UID perPhaseRef = OcppMeasurementMapping.getPerPhase(
-              sample.getMeasurand(), sample.getPhase());
-          if (perPhaseRef != null) {
-            ChannelUID perPhaseUid = new ChannelUID(getThing().getUID(), perPhaseRef.getAsString());
-            State perPhaseState = parse(measurement, perPhaseUid, sample);
-            getCallback().stateUpdated(perPhaseUid, perPhaseState);
           }
         } catch (NumberFormatException e) {
           logger.debug("Could not parse value of measurement {}", sample, e);

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMapping.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMapping.java
@@ -56,8 +56,9 @@ public class OcppMeasurementMapping {
   );
 
   // Vendor-suffix form: "Current.Import.L1" with no phase field set.
-  // Captured group holds the digit 1/2/3.
-  private final static Pattern PHASE_SUFFIX = Pattern.compile("\\.L([1-3])$");
+  // Captured group holds the full "Lx" token so the same string can be used
+  // both for stripping and for resolving the phase key in PER_PHASE.
+  private final static Pattern PHASE_SUFFIX = Pattern.compile("\\.(L[1-3])$");
 
   /**
    * Resolve every channel that should receive an update for a given
@@ -121,7 +122,7 @@ public class OcppMeasurementMapping {
     }
     // Vendor-suffix form: phase encoded in the measurand name itself.
     Matcher m = PHASE_SUFFIX.matcher(sample.getMeasurand());
-    return m.find() ? "L" + m.group(1) : null;
+    return m.find() ? m.group(1) : null;
   }
 
   private static String stripPhaseSuffix(String measurand) {

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMapping.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMapping.java
@@ -2,7 +2,12 @@ package org.connectorio.addons.binding.ocpp.internal.server;
 
 import static java.util.Map.entry;
 
+import eu.chargetime.ocpp.model.core.SampledValue;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.connectorio.addons.binding.ocpp.OcppBindingConstants;
 import org.connectorio.addons.binding.ocpp.OcppBindingConstants.ChannelRef;
 import org.openhab.core.thing.UID;
@@ -34,9 +39,9 @@ public class OcppMeasurementMapping {
     entry("Voltage", OcppBindingConstants.VOLTAGE)
   );
 
-  // Per-phase channels — populated only for measurands that meaningfully vary
-  // per phase on 3-phase chargers. Power/Energy aggregates remain single-channel
-  // (OCPP 1.6 doesn't define per-phase variants of those measurands).
+  // Measurands that have per-phase variants on 3-phase chargers. OCPP 1.6
+  // doesn't define per-phase forms of Power/Energy aggregates, so only
+  // Current.Import and Voltage are split.
   private final static Map<String, Map<String, ChannelRef>> PER_PHASE = Map.of(
     "Current.Import", Map.of(
       "L1", OcppBindingConstants.CURRENT_IMPORT_L1,
@@ -50,67 +55,77 @@ public class OcppMeasurementMapping {
     )
   );
 
-  public static UID get(String measurement) {
-    if (measurement == null) return null;
-    // Normalize vendor-suffix form ("Current.Import.L1" → "Current.Import")
-    // for the aggregate lookup so the existing single-value channel still
-    // receives updates.
-    String base = stripPhaseSuffix(measurement);
-    return MAPPING.get(base);
+  // Vendor-suffix form: "Current.Import.L1" with no phase field set.
+  // Captured group holds the digit 1/2/3.
+  private final static Pattern PHASE_SUFFIX = Pattern.compile("\\.L([1-3])$");
+
+  /**
+   * Resolve every channel that should receive an update for a given
+   * SampledValue. The caller doesn't need to know about phase strings or
+   * vendor quirks — this method is the single point of decision.
+   *
+   * <p>Returns:</p>
+   * <ul>
+   *   <li>empty list — unknown measurand</li>
+   *   <li>aggregate channel only — measurand has no per-phase split, or no
+   *       phase can be inferred</li>
+   *   <li>aggregate + per-phase channel — when a phase is identified from
+   *       either the {@code SampledValue.phase} field or a {@code .L1}/{@code .L2}/{@code .L3}
+   *       suffix on the measurand. Updating both gives the user free choice
+   *       of which channel to link in the item file.</li>
+   * </ul>
+   */
+  public static List<UID> channelsFor(SampledValue sample) {
+    if (sample == null || sample.getMeasurand() == null) {
+      return List.of();
+    }
+    String base = stripPhaseSuffix(sample.getMeasurand());
+    List<UID> channels = new ArrayList<>(2);
+
+    ChannelRef aggregate = MAPPING.get(base);
+    if (aggregate != null) {
+      channels.add(aggregate);
+    }
+
+    String phase = resolvePhase(sample);
+    if (phase != null) {
+      Map<String, ChannelRef> perPhase = PER_PHASE.get(base);
+      if (perPhase != null) {
+        ChannelRef phaseChannel = perPhase.get(phase);
+        if (phaseChannel != null) {
+          channels.add(phaseChannel);
+        }
+      }
+    }
+    return channels;
   }
 
   /**
-   * Resolve a per-phase channel from a SampledValue's measurand + phase fields.
-   *
-   * Two cases handled:
-   * <ol>
-   *   <li>Standard OCPP form — measurand = "Current.Import", phase = "L1"
-   *       (or "L1-N"/"L1-L2"; only the L? prefix matters).</li>
-   *   <li>Vendor-suffix form — measurand = "Current.Import.L1" with phase
-   *       null. Seen in Wallbox firmware 6.7.x. We strip the trailing
-   *       ".L1"/"L2"/"L3" off the measurand to recover the phase.</li>
-   * </ol>
-   *
-   * @return ChannelRef for the per-phase channel, or {@code null} if the
-   *         measurand isn't one we track per phase or the phase is empty.
+   * Direct measurand → channel lookup. Kept for callers that need to resolve
+   * a channel from a measurand name alone; for live MeterValues handling
+   * prefer {@link #channelsFor(SampledValue)}.
    */
-  public static UID getPerPhase(String measurement, String phase) {
+  public static UID get(String measurement) {
     if (measurement == null) return null;
-    String base = measurement;
-    String resolvedPhase = phase;
+    return MAPPING.get(stripPhaseSuffix(measurement));
+  }
 
-    // Vendor-suffix form: phase embedded in the measurand, no phase field.
-    if (resolvedPhase == null || resolvedPhase.isEmpty()) {
-      String suffix = extractPhaseSuffix(measurement);
-      if (suffix == null) return null;
-      base = measurement.substring(0, measurement.length() - suffix.length() - 1);
-      resolvedPhase = suffix;
+  private static String resolvePhase(SampledValue sample) {
+    // Standard form: phase field set, possibly with line-neutral suffix like "L1-N".
+    String phase = sample.getPhase();
+    if (phase != null && phase.length() >= 2) {
+      String head = phase.substring(0, 2);
+      if ("L1".equals(head) || "L2".equals(head) || "L3".equals(head)) {
+        return head;
+      }
     }
-
-    // Normalize "L1-N" / "L1-L2" style — only the leading "L?" identifies the phase.
-    String phaseKey = normalizePhaseKey(resolvedPhase);
-    if (phaseKey == null) return null;
-
-    Map<String, ChannelRef> phases = PER_PHASE.get(base);
-    return phases == null ? null : phases.get(phaseKey);
+    // Vendor-suffix form: phase encoded in the measurand name itself.
+    Matcher m = PHASE_SUFFIX.matcher(sample.getMeasurand());
+    return m.find() ? "L" + m.group(1) : null;
   }
 
   private static String stripPhaseSuffix(String measurand) {
-    String suffix = extractPhaseSuffix(measurand);
-    return suffix == null ? measurand : measurand.substring(0, measurand.length() - suffix.length() - 1);
-  }
-
-  private static String extractPhaseSuffix(String measurand) {
-    int dot = measurand.lastIndexOf('.');
-    if (dot <= 0 || dot == measurand.length() - 1) return null;
-    String tail = measurand.substring(dot + 1);
-    return ("L1".equals(tail) || "L2".equals(tail) || "L3".equals(tail)) ? tail : null;
-  }
-
-  private static String normalizePhaseKey(String phase) {
-    if (phase == null || phase.length() < 2) return null;
-    String head = phase.substring(0, 2);
-    return ("L1".equals(head) || "L2".equals(head) || "L3".equals(head)) ? head : null;
+    return PHASE_SUFFIX.matcher(measurand).replaceAll("");
   }
 
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMapping.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMapping.java
@@ -34,12 +34,83 @@ public class OcppMeasurementMapping {
     entry("Voltage", OcppBindingConstants.VOLTAGE)
   );
 
+  // Per-phase channels — populated only for measurands that meaningfully vary
+  // per phase on 3-phase chargers. Power/Energy aggregates remain single-channel
+  // (OCPP 1.6 doesn't define per-phase variants of those measurands).
+  private final static Map<String, Map<String, ChannelRef>> PER_PHASE = Map.of(
+    "Current.Import", Map.of(
+      "L1", OcppBindingConstants.CURRENT_IMPORT_L1,
+      "L2", OcppBindingConstants.CURRENT_IMPORT_L2,
+      "L3", OcppBindingConstants.CURRENT_IMPORT_L3
+    ),
+    "Voltage", Map.of(
+      "L1", OcppBindingConstants.VOLTAGE_L1,
+      "L2", OcppBindingConstants.VOLTAGE_L2,
+      "L3", OcppBindingConstants.VOLTAGE_L3
+    )
+  );
+
   public static UID get(String measurement) {
-    if (MAPPING.containsKey(measurement)) {
-      return MAPPING.get(measurement);
+    if (measurement == null) return null;
+    // Normalize vendor-suffix form ("Current.Import.L1" → "Current.Import")
+    // for the aggregate lookup so the existing single-value channel still
+    // receives updates.
+    String base = stripPhaseSuffix(measurement);
+    return MAPPING.get(base);
+  }
+
+  /**
+   * Resolve a per-phase channel from a SampledValue's measurand + phase fields.
+   *
+   * Two cases handled:
+   * <ol>
+   *   <li>Standard OCPP form — measurand = "Current.Import", phase = "L1"
+   *       (or "L1-N"/"L1-L2"; only the L? prefix matters).</li>
+   *   <li>Vendor-suffix form — measurand = "Current.Import.L1" with phase
+   *       null. Seen in Wallbox firmware 6.7.x. We strip the trailing
+   *       ".L1"/"L2"/"L3" off the measurand to recover the phase.</li>
+   * </ol>
+   *
+   * @return ChannelRef for the per-phase channel, or {@code null} if the
+   *         measurand isn't one we track per phase or the phase is empty.
+   */
+  public static UID getPerPhase(String measurement, String phase) {
+    if (measurement == null) return null;
+    String base = measurement;
+    String resolvedPhase = phase;
+
+    // Vendor-suffix form: phase embedded in the measurand, no phase field.
+    if (resolvedPhase == null || resolvedPhase.isEmpty()) {
+      String suffix = extractPhaseSuffix(measurement);
+      if (suffix == null) return null;
+      base = measurement.substring(0, measurement.length() - suffix.length() - 1);
+      resolvedPhase = suffix;
     }
 
-    return null;
+    // Normalize "L1-N" / "L1-L2" style — only the leading "L?" identifies the phase.
+    String phaseKey = normalizePhaseKey(resolvedPhase);
+    if (phaseKey == null) return null;
+
+    Map<String, ChannelRef> phases = PER_PHASE.get(base);
+    return phases == null ? null : phases.get(phaseKey);
+  }
+
+  private static String stripPhaseSuffix(String measurand) {
+    String suffix = extractPhaseSuffix(measurand);
+    return suffix == null ? measurand : measurand.substring(0, measurand.length() - suffix.length() - 1);
+  }
+
+  private static String extractPhaseSuffix(String measurand) {
+    int dot = measurand.lastIndexOf('.');
+    if (dot <= 0 || dot == measurand.length() - 1) return null;
+    String tail = measurand.substring(dot + 1);
+    return ("L1".equals(tail) || "L2".equals(tail) || "L3".equals(tail)) ? tail : null;
+  }
+
+  private static String normalizePhaseKey(String phase) {
+    if (phase == null || phase.length() < 2) return null;
+    String head = phase.substring(0, 2);
+    return ("L1".equals(head) || "L2".equals(head) || "L3".equals(head)) ? head : null;
   }
 
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -145,11 +145,11 @@
       </channel>
       <channel id="currentImport" typeId="current">
         <label>Current.Import</label>
-        <description>Instantaneous current flow to EV (aggregate; on 3-phase chargers this is the last-reported phase). Use the per-phase channels below for stable 3-phase readings.</description>
+        <description>Instantaneous current flow to EV. Updated from every SampledValue whose measurand resolves to Current.Import, regardless of phase; link this if you want a single channel that follows the latest reading.</description>
       </channel>
       <channel id="currentImportL1" typeId="current">
         <label>Current.Import L1</label>
-        <description>Instantaneous current flow to EV on phase L1.</description>
+        <description>Instantaneous current flow to EV on phase L1. Filled when the charger reports a phase (either via SampledValue.phase or a measurand suffix).</description>
       </channel>
       <channel id="currentImportL2" typeId="current">
         <label>Current.Import L2</label>
@@ -237,11 +237,11 @@
       </channel>
       <channel id="voltage" typeId="voltage">
         <label>Voltage</label>
-        <description>Instantaneous AC RMS supply voltage (aggregate; on 3-phase chargers this is the last-reported phase). Use the per-phase channels below for stable 3-phase readings.</description>
+        <description>Instantaneous AC RMS supply voltage. Updated from every SampledValue whose measurand resolves to Voltage, regardless of phase; link this if you want a single channel that follows the latest reading.</description>
       </channel>
       <channel id="voltageL1" typeId="voltage">
         <label>Voltage L1</label>
-        <description>Instantaneous AC RMS supply voltage on phase L1.</description>
+        <description>Instantaneous AC RMS supply voltage on phase L1. Filled when the charger reports a phase.</description>
       </channel>
       <channel id="voltageL2" typeId="voltage">
         <label>Voltage L2</label>

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -145,11 +145,11 @@
       </channel>
       <channel id="currentImport" typeId="current">
         <label>Current.Import</label>
-        <description>Instantaneous current flow to EV. Updated from every SampledValue whose measurand resolves to Current.Import, regardless of phase; link this if you want a single channel that follows the latest reading.</description>
+        <description>Instantaneous current flow to EV. Last-write-wins across phases: if the charger sends per-phase Current.Import samples, the last phase processed lands here. Single-phase chargers can link this directly; for true per-phase telemetry use the L1/L2/L3 channels.</description>
       </channel>
       <channel id="currentImportL1" typeId="current">
         <label>Current.Import L1</label>
-        <description>Instantaneous current flow to EV on phase L1. Filled when the charger reports a phase (either via SampledValue.phase or a measurand suffix).</description>
+        <description>Instantaneous current flow to EV on phase L1. Populated when the charger identifies a phase via either SampledValue.phase or a vendor measurand suffix (e.g. Current.Import.L1).</description>
       </channel>
       <channel id="currentImportL2" typeId="current">
         <label>Current.Import L2</label>

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -145,7 +145,19 @@
       </channel>
       <channel id="currentImport" typeId="current">
         <label>Current.Import</label>
-        <description>Instantaneous current flow to EV</description>
+        <description>Instantaneous current flow to EV (aggregate; on 3-phase chargers this is the last-reported phase). Use the per-phase channels below for stable 3-phase readings.</description>
+      </channel>
+      <channel id="currentImportL1" typeId="current">
+        <label>Current.Import L1</label>
+        <description>Instantaneous current flow to EV on phase L1.</description>
+      </channel>
+      <channel id="currentImportL2" typeId="current">
+        <label>Current.Import L2</label>
+        <description>Instantaneous current flow to EV on phase L2.</description>
+      </channel>
+      <channel id="currentImportL3" typeId="current">
+        <label>Current.Import L3</label>
+        <description>Instantaneous current flow to EV on phase L3.</description>
       </channel>
       <channel id="currentOffered" typeId="current">
         <label>Current.Offered</label>
@@ -225,7 +237,19 @@
       </channel>
       <channel id="voltage" typeId="voltage">
         <label>Voltage</label>
-        <description>Instantaneous AC RMS supply voltage</description>
+        <description>Instantaneous AC RMS supply voltage (aggregate; on 3-phase chargers this is the last-reported phase). Use the per-phase channels below for stable 3-phase readings.</description>
+      </channel>
+      <channel id="voltageL1" typeId="voltage">
+        <label>Voltage L1</label>
+        <description>Instantaneous AC RMS supply voltage on phase L1.</description>
+      </channel>
+      <channel id="voltageL2" typeId="voltage">
+        <label>Voltage L2</label>
+        <description>Instantaneous AC RMS supply voltage on phase L2.</description>
+      </channel>
+      <channel id="voltageL3" typeId="voltage">
+        <label>Voltage L3</label>
+        <description>Instantaneous AC RMS supply voltage on phase L3.</description>
       </channel>
       <channel id="chargeLimit" typeId="current">
         <label>Charge Limit</label>

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMappingTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMappingTest.java
@@ -1,0 +1,78 @@
+package org.connectorio.addons.binding.ocpp.internal.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.connectorio.addons.binding.ocpp.OcppBindingConstants;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.thing.UID;
+
+class OcppMeasurementMappingTest {
+
+  @Test
+  void aggregateLookupReturnsBaseChannel() {
+    assertThat(OcppMeasurementMapping.get("Current.Import"))
+        .isEqualTo(OcppBindingConstants.CURRENT_IMPORT);
+    assertThat(OcppMeasurementMapping.get("Voltage"))
+        .isEqualTo(OcppBindingConstants.VOLTAGE);
+  }
+
+  @Test
+  void aggregateLookupReturnsNullForUnknown() {
+    assertThat(OcppMeasurementMapping.get("NotAMeasurand")).isNull();
+    assertThat(OcppMeasurementMapping.get(null)).isNull();
+  }
+
+  @Test
+  void vendorSuffixResolvesAggregateToBase() {
+    // Wallbox FW 6.7.x emits "Current.Import.L1" with no phase field;
+    // the aggregate channel should still get updated from the base measurand.
+    assertThat(OcppMeasurementMapping.get("Current.Import.L1"))
+        .isEqualTo(OcppBindingConstants.CURRENT_IMPORT);
+    assertThat(OcppMeasurementMapping.get("Voltage.L3"))
+        .isEqualTo(OcppBindingConstants.VOLTAGE);
+  }
+
+  @Test
+  void perPhaseFromStandardPhaseField() {
+    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", "L1"))
+        .isEqualTo(OcppBindingConstants.CURRENT_IMPORT_L1);
+    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", "L2"))
+        .isEqualTo(OcppBindingConstants.CURRENT_IMPORT_L2);
+    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", "L3"))
+        .isEqualTo(OcppBindingConstants.CURRENT_IMPORT_L3);
+    assertThat(OcppMeasurementMapping.getPerPhase("Voltage", "L1"))
+        .isEqualTo(OcppBindingConstants.VOLTAGE_L1);
+  }
+
+  @Test
+  void perPhaseFromVendorSuffixWhenPhaseFieldMissing() {
+    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import.L1", null))
+        .isEqualTo(OcppBindingConstants.CURRENT_IMPORT_L1);
+    assertThat(OcppMeasurementMapping.getPerPhase("Voltage.L3", ""))
+        .isEqualTo(OcppBindingConstants.VOLTAGE_L3);
+  }
+
+  @Test
+  void perPhaseNormalisesPhaseWithLineNeutralSuffix() {
+    // OCPP allows phases like "L1-N", "L1-L2"; only the leading L? identifies it.
+    assertThat(OcppMeasurementMapping.getPerPhase("Voltage", "L1-N"))
+        .isEqualTo(OcppBindingConstants.VOLTAGE_L1);
+    assertThat(OcppMeasurementMapping.getPerPhase("Voltage", "L2-L3"))
+        .isEqualTo(OcppBindingConstants.VOLTAGE_L2);
+  }
+
+  @Test
+  void perPhaseReturnsNullForMeasurandsWithoutPerPhaseSplit() {
+    // Power.Active.Import has no per-phase channels in OCPP 1.6.
+    assertThat(OcppMeasurementMapping.getPerPhase("Power.Active.Import", "L1")).isNull();
+    assertThat(OcppMeasurementMapping.getPerPhase("Energy.Active.Import.Register", "L1")).isNull();
+  }
+
+  @Test
+  void perPhaseReturnsNullForBadPhase() {
+    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", null)).isNull();
+    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", "")).isNull();
+    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", "X")).isNull();
+    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", "L9")).isNull();
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMappingTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMappingTest.java
@@ -2,14 +2,23 @@ package org.connectorio.addons.binding.ocpp.internal.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import eu.chargetime.ocpp.model.core.SampledValue;
 import org.connectorio.addons.binding.ocpp.OcppBindingConstants;
 import org.junit.jupiter.api.Test;
-import org.openhab.core.thing.UID;
 
 class OcppMeasurementMappingTest {
 
+  private static SampledValue sample(String measurand, String phase) {
+    SampledValue v = new SampledValue();
+    v.setMeasurand(measurand);
+    if (phase != null) {
+      v.setPhase(phase);
+    }
+    return v;
+  }
+
   @Test
-  void aggregateLookupReturnsBaseChannel() {
+  void getReturnsAggregateChannelForKnownMeasurand() {
     assertThat(OcppMeasurementMapping.get("Current.Import"))
         .isEqualTo(OcppBindingConstants.CURRENT_IMPORT);
     assertThat(OcppMeasurementMapping.get("Voltage"))
@@ -17,15 +26,7 @@ class OcppMeasurementMappingTest {
   }
 
   @Test
-  void aggregateLookupReturnsNullForUnknown() {
-    assertThat(OcppMeasurementMapping.get("NotAMeasurand")).isNull();
-    assertThat(OcppMeasurementMapping.get(null)).isNull();
-  }
-
-  @Test
-  void vendorSuffixResolvesAggregateToBase() {
-    // Wallbox FW 6.7.x emits "Current.Import.L1" with no phase field;
-    // the aggregate channel should still get updated from the base measurand.
+  void getStripsPhaseSuffixSoVendorFormResolvesToAggregate() {
     assertThat(OcppMeasurementMapping.get("Current.Import.L1"))
         .isEqualTo(OcppBindingConstants.CURRENT_IMPORT);
     assertThat(OcppMeasurementMapping.get("Voltage.L3"))
@@ -33,46 +34,78 @@ class OcppMeasurementMappingTest {
   }
 
   @Test
-  void perPhaseFromStandardPhaseField() {
-    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", "L1"))
-        .isEqualTo(OcppBindingConstants.CURRENT_IMPORT_L1);
-    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", "L2"))
-        .isEqualTo(OcppBindingConstants.CURRENT_IMPORT_L2);
-    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", "L3"))
-        .isEqualTo(OcppBindingConstants.CURRENT_IMPORT_L3);
-    assertThat(OcppMeasurementMapping.getPerPhase("Voltage", "L1"))
-        .isEqualTo(OcppBindingConstants.VOLTAGE_L1);
+  void getReturnsNullForUnknown() {
+    assertThat(OcppMeasurementMapping.get("NotAMeasurand")).isNull();
+    assertThat(OcppMeasurementMapping.get(null)).isNull();
   }
 
   @Test
-  void perPhaseFromVendorSuffixWhenPhaseFieldMissing() {
-    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import.L1", null))
-        .isEqualTo(OcppBindingConstants.CURRENT_IMPORT_L1);
-    assertThat(OcppMeasurementMapping.getPerPhase("Voltage.L3", ""))
-        .isEqualTo(OcppBindingConstants.VOLTAGE_L3);
+  void channelsForReturnsAggregateOnlyWhenNoPhase() {
+    assertThat(OcppMeasurementMapping.channelsFor(sample("Current.Import", null)))
+        .containsExactly(OcppBindingConstants.CURRENT_IMPORT);
+    assertThat(OcppMeasurementMapping.channelsFor(sample("Power.Active.Import", null)))
+        .containsExactly(OcppBindingConstants.POWER_ACTIVE_IMPORT);
   }
 
   @Test
-  void perPhaseNormalisesPhaseWithLineNeutralSuffix() {
-    // OCPP allows phases like "L1-N", "L1-L2"; only the leading L? identifies it.
-    assertThat(OcppMeasurementMapping.getPerPhase("Voltage", "L1-N"))
-        .isEqualTo(OcppBindingConstants.VOLTAGE_L1);
-    assertThat(OcppMeasurementMapping.getPerPhase("Voltage", "L2-L3"))
-        .isEqualTo(OcppBindingConstants.VOLTAGE_L2);
+  void channelsForReturnsBothAggregateAndPerPhaseWhenPhaseFieldSet() {
+    assertThat(OcppMeasurementMapping.channelsFor(sample("Current.Import", "L1")))
+        .containsExactly(
+            OcppBindingConstants.CURRENT_IMPORT,
+            OcppBindingConstants.CURRENT_IMPORT_L1);
+    assertThat(OcppMeasurementMapping.channelsFor(sample("Voltage", "L3")))
+        .containsExactly(
+            OcppBindingConstants.VOLTAGE,
+            OcppBindingConstants.VOLTAGE_L3);
   }
 
   @Test
-  void perPhaseReturnsNullForMeasurandsWithoutPerPhaseSplit() {
-    // Power.Active.Import has no per-phase channels in OCPP 1.6.
-    assertThat(OcppMeasurementMapping.getPerPhase("Power.Active.Import", "L1")).isNull();
-    assertThat(OcppMeasurementMapping.getPerPhase("Energy.Active.Import.Register", "L1")).isNull();
+  void channelsForReadsPhaseFromVendorSuffixWhenFieldMissing() {
+    assertThat(OcppMeasurementMapping.channelsFor(sample("Current.Import.L2", null)))
+        .containsExactly(
+            OcppBindingConstants.CURRENT_IMPORT,
+            OcppBindingConstants.CURRENT_IMPORT_L2);
+    assertThat(OcppMeasurementMapping.channelsFor(sample("Voltage.L1", null)))
+        .containsExactly(
+            OcppBindingConstants.VOLTAGE,
+            OcppBindingConstants.VOLTAGE_L1);
   }
 
   @Test
-  void perPhaseReturnsNullForBadPhase() {
-    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", null)).isNull();
-    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", "")).isNull();
-    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", "X")).isNull();
-    assertThat(OcppMeasurementMapping.getPerPhase("Current.Import", "L9")).isNull();
+  void channelsForNormalisesPhaseWithLineNeutralSuffix() {
+    // OCPP allows phases like "L1-N", "L1-L2"; only the leading L? identifies the phase.
+    assertThat(OcppMeasurementMapping.channelsFor(sample("Voltage", "L1-N")))
+        .containsExactly(
+            OcppBindingConstants.VOLTAGE,
+            OcppBindingConstants.VOLTAGE_L1);
+    assertThat(OcppMeasurementMapping.channelsFor(sample("Voltage", "L2-L3")))
+        .containsExactly(
+            OcppBindingConstants.VOLTAGE,
+            OcppBindingConstants.VOLTAGE_L2);
+  }
+
+  @Test
+  void channelsForSkipsPerPhaseForMeasurandsWithoutPerPhaseSplit() {
+    // OCPP 1.6 doesn't define per-phase variants for Power/Energy aggregates.
+    assertThat(OcppMeasurementMapping.channelsFor(sample("Power.Active.Import", "L1")))
+        .containsExactly(OcppBindingConstants.POWER_ACTIVE_IMPORT);
+    assertThat(OcppMeasurementMapping.channelsFor(sample("Energy.Active.Import.Register", "L1")))
+        .containsExactly(OcppBindingConstants.ENERGY_ACTIVE_IMPORT);
+  }
+
+  @Test
+  void channelsForReturnsEmptyForUnknownOrNull() {
+    assertThat(OcppMeasurementMapping.channelsFor(sample("NotAMeasurand", null))).isEmpty();
+    assertThat(OcppMeasurementMapping.channelsFor(null)).isEmpty();
+    assertThat(OcppMeasurementMapping.channelsFor(sample(null, null))).isEmpty();
+  }
+
+  @Test
+  void channelsForIgnoresInvalidPhase() {
+    // Bogus phase string falls back to aggregate-only.
+    assertThat(OcppMeasurementMapping.channelsFor(sample("Current.Import", "X")))
+        .containsExactly(OcppBindingConstants.CURRENT_IMPORT);
+    assertThat(OcppMeasurementMapping.channelsFor(sample("Current.Import", "L9")))
+        .containsExactly(OcppBindingConstants.CURRENT_IMPORT);
   }
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMappingTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/OcppMeasurementMappingTest.java
@@ -1,6 +1,8 @@
 package org.connectorio.addons.binding.ocpp.internal.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import eu.chargetime.ocpp.model.core.SampledValue;
 import org.connectorio.addons.binding.ocpp.OcppBindingConstants;
@@ -8,12 +10,18 @@ import org.junit.jupiter.api.Test;
 
 class OcppMeasurementMappingTest {
 
+  /**
+   * The Java-OCA-OCPP library validates {@link SampledValue#setMeasurand} and
+   * {@link SampledValue#setPhase} setters strictly, throwing on values that
+   * aren't in the OCPP 1.6 enumeration. Real chargers in the wild send vendor
+   * variants like {@code Current.Import.L2} and stray phase strings; we need
+   * to exercise those paths in the mapper without the library blocking us
+   * before the assertion runs. Mocking SampledValue bypasses the setters.
+   */
   private static SampledValue sample(String measurand, String phase) {
-    SampledValue v = new SampledValue();
-    v.setMeasurand(measurand);
-    if (phase != null) {
-      v.setPhase(phase);
-    }
+    SampledValue v = mock(SampledValue.class);
+    when(v.getMeasurand()).thenReturn(measurand);
+    when(v.getPhase()).thenReturn(phase);
     return v;
   }
 


### PR DESCRIPTION
Adds per-phase channels for Current.Import and Voltage so 3-phase chargers
stop overwriting the same aggregate channel on every phase update.

Resolves the SampledValue.phase field OR the vendor-specific measurand suffix
(Wallbox FW 6.7.x emits "Current.Import.L1" without a phase field). Aggregate
currentImport / voltage channels remain populated for existing item links.

Per-phase split applies to Current.Import and Voltage only — OCPP 1.6 doesn't
define per-phase variants of Power/Energy aggregates.

Tested against Wallbox Copper SB + Pulsar Plus (FW 6.7.38) and Phoenix Contact
CHARX SEC-3xxx (FW 1.9.0) — the latter has no internal energy meter so the
exercise was limited to vendor-form parsing tests, not live 3-phase reads.

Refs #131. Channel layout follows Option 1 confirmed by @PRosenb (three
explicit per-phase channels alongside the aggregate).
