### PR TITLE
[ocpp] Target SetChargingProfile at the connector's actual id

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ConnectorConfig.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ConnectorConfig.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2022-2022 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.binding.ocpp.internal.config;
+
+import org.connectorio.addons.binding.config.Configuration;
+
+public class ConnectorConfig implements Configuration {
+  public static final String DEFAULT_REMOTE_START_TAG = "openhab";
+  public Integer connectorId;
+  public String remoteStartTag = DEFAULT_REMOTE_START_TAG;
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandler.java
@@ -28,12 +28,12 @@ public class ChargeLimitCommandHandler {
             logger.warn("Unsupported command type for chargeLimit: {}", command.getClass());
             return;
         }
-        sendChargingProfile(limit, context.getOcppSender(), context.getChargerSerialNumber());
+        sendChargingProfile(limit, context.getOcppSender(), context.getChargerSerialNumber(), context.getConnectorId());
     }
 
-    private void sendChargingProfile(double limit, OcppSender ocppSender, String chargerSerialNumber) {
-        if (ocppSender == null || chargerSerialNumber == null) {
-            logger.warn("OcppSender or charger serial not set. Cannot send charging profile.");
+    private void sendChargingProfile(double limit, OcppSender ocppSender, String chargerSerialNumber, Integer connectorId) {
+        if (ocppSender == null || chargerSerialNumber == null || connectorId == null) {
+            logger.warn("OcppSender, charger serial or connector id not set. Cannot send charging profile.");
             return;
         }
 
@@ -53,7 +53,7 @@ public class ChargeLimitCommandHandler {
         profile.setChargingProfileKind(ChargingProfileKindType.Relative);
         profile.setChargingSchedule(schedule);
 
-        SetChargingProfileRequest setProfileRequest = new SetChargingProfileRequest(1, profile);
+        SetChargingProfileRequest setProfileRequest = new SetChargingProfileRequest(connectorId, profile);
         
         ocppSender.send(chargerRef, setProfileRequest).whenComplete((confirmation, throwable) -> {
             if (throwable != null) {

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorCommandContext.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorCommandContext.java
@@ -7,4 +7,5 @@ public interface ConnectorCommandContext {
     String getChargerSerialNumber();
     String getRemoteStartTag();
     Integer getCurrentTransactionId();
+    Integer getConnectorId();
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.measure.Quantity;
 import org.connectorio.addons.binding.handler.GenericThingHandlerBase;
 import org.connectorio.addons.binding.ocpp.OcppBindingConstants;
-import org.connectorio.addons.binding.ocpp.internal.config.ChargerConfig;
+import org.connectorio.addons.binding.ocpp.internal.config.ConnectorConfig;
 import org.connectorio.addons.binding.ocpp.internal.server.OcppMeasurementMapping;
 import org.connectorio.addons.binding.ocpp.internal.server.listener.MeterValuesHandler;
 import org.connectorio.addons.binding.ocpp.internal.server.listener.StatusNotificationHandler;
@@ -46,16 +46,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tech.units.indriya.quantity.Quantities;
 
-public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeHandler, ChargerConfig> implements
+public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeHandler, ConnectorConfig> implements
   StatusNotificationHandler, TransactionHandler, MeterValuesHandler, ConnectorCommandContext {
 
   private final AtomicInteger transactionId = new AtomicInteger();
   private final Logger logger = LoggerFactory.getLogger(ConnectorThingHandler.class);
-  
+
   private OcppSender ocppSender;
   private String chargerSerialNumber;
   private Integer currentTransactionId;
   private String remoteStartTag;
+  private Integer connectorId;
 
   private final ChargeLimitCommandHandler chargeLimitHandler;
   private final ChargingCommandHandler chargingHandler;
@@ -96,15 +97,21 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
   }
 
   @Override
+  public Integer getConnectorId() {
+    return connectorId;
+  }
+
+  @Override
   public void initialize() {
-    Optional<ChargerConfig> config = getThingConfig();
+    Optional<ConnectorConfig> config = getThingConfig();
     if (config.isPresent()) {
       remoteStartTag = config.get().remoteStartTag;
       if (remoteStartTag == null || remoteStartTag.trim().isEmpty()) {
-        remoteStartTag = ChargerConfig.DEFAULT_REMOTE_START_TAG;
+        remoteStartTag = ConnectorConfig.DEFAULT_REMOTE_START_TAG;
       }
+      connectorId = config.get().connectorId;
     } else {
-      remoteStartTag = ChargerConfig.DEFAULT_REMOTE_START_TAG;
+      remoteStartTag = ConnectorConfig.DEFAULT_REMOTE_START_TAG;
     }
     updateStatus(ThingStatus.ONLINE);
   }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandlerTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandlerTest.java
@@ -45,6 +45,7 @@ class ChargeLimitCommandHandlerTest {
     // given
     when(context.getOcppSender()).thenReturn(sender);
     when(context.getChargerSerialNumber()).thenReturn("charger-serial");
+    when(context.getConnectorId()).thenReturn(2);
     when(sender.send(any(ChargerReference.class), any(Request.class)))
       .thenReturn(CompletableFuture.completedFuture(null));
 
@@ -56,6 +57,7 @@ class ChargeLimitCommandHandlerTest {
     verify(sender).send(any(ChargerReference.class), requestCaptor.capture());
 
     assertThat(requestCaptor.getValue()).isInstanceOf(SetChargingProfileRequest.class);
+    assertThat(((SetChargingProfileRequest) requestCaptor.getValue()).getConnectorId()).isEqualTo(2);
   }
 
   @Test
@@ -63,6 +65,7 @@ class ChargeLimitCommandHandlerTest {
     // given
     when(context.getOcppSender()).thenReturn(sender);
     when(context.getChargerSerialNumber()).thenReturn("charger-serial");
+    when(context.getConnectorId()).thenReturn(1);
     when(sender.send(any(ChargerReference.class), any(Request.class)))
       .thenReturn(CompletableFuture.completedFuture(null));
 
@@ -76,6 +79,21 @@ class ChargeLimitCommandHandlerTest {
     verify(sender).send(any(ChargerReference.class), requestCaptor.capture());
 
     assertThat(requestCaptor.getValue()).isInstanceOf(SetChargingProfileRequest.class);
+    assertThat(((SetChargingProfileRequest) requestCaptor.getValue()).getConnectorId()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotSendWhenConnectorIdMissing() {
+    // given
+    when(context.getOcppSender()).thenReturn(sender);
+    when(context.getChargerSerialNumber()).thenReturn("charger-serial");
+    when(context.getConnectorId()).thenReturn(null);
+
+    // when
+    handler.handle(new DecimalType(10), context);
+
+    // then
+    verify(sender, never()).send(any(ChargerReference.class), any(Request.class));
   }
 
   @Test


### PR DESCRIPTION
`ChargeLimitCommandHandler` hardcoded `connectorId=1` on the outbound `SetChargingProfileRequest`. On a multi-connector charger like Phoenix Contact CHARX SEC-3xxx (FW 1.9.0), the two connector Things both wrote to connector 1 — so a chargeLimit command sent to connector 2 silently moved connector 1's PWM and connector 2 stayed on whatever profile it had.

Threads the connector id through `ConnectorCommandContext`. `ConnectorThingHandler` now reads it from the Thing config (already declared in `thing-types.xml` as a required parameter on `co7io-ocpp:connector`). Split out of `ChargerConfig` into a focused `ConnectorConfig` so `ChargerConfig` stays the charger-bridge config and doesn't carry connector-only fields. Single-connector chargers (Wallbox Copper SB / Pulsar Plus on this site) keep working unchanged because their declared `connectorId` is `1`.

Open question: `remoteStartTag` still lives on both `ChargerConfig` and `ConnectorConfig` because the existing `thing-types.xml` declares it on both. Happy to move it to `ConnectorConfig` only as a follow-up if you'd rather.
