### PR TITLE
[ocpp] Auto-configure MeterValues on BootNotification

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ServerConfig.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ServerConfig.java
@@ -28,6 +28,10 @@ public class ServerConfig implements Configuration {
   public String initialOcularEcoMode;
   public int pingInterval = 60;
 
+  public int meterValueSampleInterval = 30;
+  public String meterValuesData = "Energy.Active.Import.Register,Power.Active.Import,Current.Import,Voltage";
+  public int clockAlignedDataInterval = 30;
+
   public List<String> chargers;
   public List<String> tags;
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ServerBridgeHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ServerBridgeHandler.java
@@ -41,6 +41,7 @@ import org.connectorio.addons.binding.ocpp.internal.server.CompositeRequestListe
 import org.connectorio.addons.binding.ocpp.internal.server.OcppServer;
 import org.connectorio.addons.binding.ocpp.internal.server.adapter.AuthorizationIdTagAdapter;
 import org.connectorio.addons.binding.ocpp.internal.server.adapter.BootRegistrationAdapter;
+import org.connectorio.addons.binding.ocpp.internal.server.adapter.MeterValuesConfigAdapter;
 import org.connectorio.addons.binding.ocpp.internal.server.adapter.RequestListenerAdapter;
 import org.connectorio.addons.binding.ocpp.internal.server.custom.OcularSolarEcoMode;
 import org.openhab.core.net.NetworkAddressService;
@@ -103,6 +104,8 @@ public class ServerBridgeHandler extends GenericBridgeHandlerBase<ServerConfig> 
       new OcularSolarEcoMode(config.initialOcularEcoMode),
       config.pingInterval
     );
+    eventHandlers.addFirst(new MeterValuesConfigAdapter(bootAdapter, server,
+      config.meterValueSampleInterval, config.meterValuesData, config.clockAlignedDataInterval));
     server.activate();
     updateStatus(ThingStatus.ONLINE);
   }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/MeterValuesConfigAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/MeterValuesConfigAdapter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022-2022 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.binding.ocpp.internal.server.adapter;
+
+import eu.chargetime.ocpp.model.core.BootNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.BootNotificationRequest;
+import eu.chargetime.ocpp.model.core.ChangeConfigurationRequest;
+import java.util.UUID;
+import org.connectorio.addons.binding.ocpp.internal.OcppSender;
+import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
+import org.connectorio.addons.binding.ocpp.internal.server.OcppChargerSessionRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MeterValuesConfigAdapter extends CoreEventHandlerAdapter {
+
+  private final Logger logger = LoggerFactory.getLogger(MeterValuesConfigAdapter.class);
+  private final OcppChargerSessionRegistry sessionRegistry;
+  private final OcppSender sender;
+  private final int sampleInterval;
+  private final String sampledData;
+  private final int clockAlignedInterval;
+
+  public MeterValuesConfigAdapter(OcppChargerSessionRegistry sessionRegistry, OcppSender sender,
+      int sampleInterval, String sampledData, int clockAlignedInterval) {
+    this.sessionRegistry = sessionRegistry;
+    this.sender = sender;
+    this.sampleInterval = sampleInterval;
+    this.sampledData = sampledData;
+    this.clockAlignedInterval = clockAlignedInterval;
+  }
+
+  @Override
+  public BootNotificationConfirmation handleBootNotificationRequest(UUID sessionIndex, BootNotificationRequest request) {
+    ChargerReference reference = sessionRegistry.getCharger(sessionIndex);
+    if (reference == null) {
+      return null;
+    }
+    apply(reference, "MeterValueSampleInterval", Integer.toString(sampleInterval));
+    apply(reference, "MeterValuesSampledData", sampledData);
+    apply(reference, "MeterValuesAlignedData", sampledData);
+    apply(reference, "ClockAlignedDataInterval", Integer.toString(clockAlignedInterval));
+    return null;
+  }
+
+  private void apply(ChargerReference reference, String key, String value) {
+    sender.send(reference, new ChangeConfigurationRequest(key, value)).whenComplete((confirmation, ex) -> {
+      if (ex != null) {
+        logger.warn("ChangeConfiguration[{}] for {} failed: {}", key, reference, ex.getMessage());
+      } else {
+        logger.debug("ChangeConfiguration[{}={}] for {}: {}", key, value, reference, confirmation);
+      }
+    });
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -79,6 +79,36 @@
         <unitLabel>s</unitLabel>
         <advanced>true</advanced>
       </parameter>
+      <parameter name="meterValueSampleInterval" type="integer" required="false" min="0">
+        <label>MeterValue Sample Interval</label>
+        <description>
+          Seconds between MeterValues samples during an active transaction.
+          Pushed to each connecting charger on BootNotification.
+        </description>
+        <default>30</default>
+        <unitLabel>s</unitLabel>
+        <advanced>true</advanced>
+      </parameter>
+      <parameter name="meterValuesData" type="text" required="false">
+        <label>MeterValues Measurands</label>
+        <description>
+          Comma-separated OCPP measurand list pushed as both MeterValuesSampledData
+          (during transactions) and MeterValuesAlignedData (clock-aligned, idle).
+        </description>
+        <default>Energy.Active.Import.Register,Power.Active.Import,Current.Import,Voltage</default>
+        <advanced>true</advanced>
+      </parameter>
+      <parameter name="clockAlignedDataInterval" type="integer" required="false" min="0">
+        <label>Clock-Aligned Data Interval</label>
+        <description>
+          Seconds between clock-aligned MeterValues pushes. Set to 0 to disable
+          idle telemetry; chargers that don't support clock-aligned values
+          respond Rejected and the setting is logged.
+        </description>
+        <default>30</default>
+        <unitLabel>s</unitLabel>
+        <advanced>true</advanced>
+      </parameter>
     </config-description>
   </bridge-type>
 


### PR DESCRIPTION
Without explicit `ChangeConfiguration`, chargers stick to their vendor defaults. Common consequences: no MeterValues outside of an active transaction (`ClockAlignedDataInterval=0` by default on most chargers I tested), and per-vendor measurand choices that don't match what the binding expects to parse.

New `MeterValuesConfigAdapter` fires four `ChangeConfiguration` requests on `BootNotification` — `MeterValueSampleInterval`, `MeterValuesSampledData`, `MeterValuesAlignedData`, `ClockAlignedDataInterval`. Three new server-bridge config parameters (advanced, defaults 30s / sane measurand list / 30s). Set `clockAlignedDataInterval=0` to disable idle telemetry.

Verified against Wallbox Copper SB, Wallbox Pulsar Plus (both FW 6.7.38) and Phoenix Contact CHARX SEC-3xxx (FW 1.9.0). All three accept the four `ChangeConfiguration` calls and start emitting clock-aligned MeterValues even with no cable plugged.

Open question: opt-out (always send defaults; this PR) vs opt-in (only when a flag is explicitly set). Happy to flip to opt-in with a `autoConfigureMeterValues` boolean if you'd rather not push config to unmodified user setups.
