### PR TITLE
[ocpp] Push AuthorizeRemoteTxRequests=false on BootNotification

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ServerConfig.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ServerConfig.java
@@ -32,6 +32,7 @@ public class ServerConfig implements Configuration {
   public int meterValueSampleInterval = 30;
   public String meterValuesData = "Energy.Active.Import.Register,Power.Active.Import,Current.Import,Voltage";
   public int clockAlignedDataInterval = 30;
+  public boolean disableRemoteTxAuthorization = true;
 
   public List<String> chargers;
   public List<String> tags;

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ServerBridgeHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ServerBridgeHandler.java
@@ -42,6 +42,7 @@ import org.connectorio.addons.binding.ocpp.internal.server.OcppServer;
 import org.connectorio.addons.binding.ocpp.internal.server.adapter.AuthorizationIdTagAdapter;
 import org.connectorio.addons.binding.ocpp.internal.server.adapter.BootRegistrationAdapter;
 import org.connectorio.addons.binding.ocpp.internal.server.adapter.MeterValuesConfigAdapter;
+import org.connectorio.addons.binding.ocpp.internal.server.adapter.RemoteAuthorizationConfigAdapter;
 import org.connectorio.addons.binding.ocpp.internal.server.adapter.RequestListenerAdapter;
 import org.connectorio.addons.binding.ocpp.internal.server.custom.OcularSolarEcoMode;
 import org.openhab.core.net.NetworkAddressService;
@@ -106,6 +107,9 @@ public class ServerBridgeHandler extends GenericBridgeHandlerBase<ServerConfig> 
     );
     eventHandlers.addFirst(new MeterValuesConfigAdapter(bootAdapter, server,
       config.meterValueSampleInterval, config.meterValuesData, config.clockAlignedDataInterval));
+    if (config.disableRemoteTxAuthorization) {
+      eventHandlers.addFirst(new RemoteAuthorizationConfigAdapter(bootAdapter, server));
+    }
     server.activate();
     updateStatus(ThingStatus.ONLINE);
   }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/RemoteAuthorizationConfigAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/RemoteAuthorizationConfigAdapter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022-2022 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.binding.ocpp.internal.server.adapter;
+
+import eu.chargetime.ocpp.model.core.BootNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.BootNotificationRequest;
+import eu.chargetime.ocpp.model.core.ChangeConfigurationRequest;
+import java.util.UUID;
+import org.connectorio.addons.binding.ocpp.internal.OcppSender;
+import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
+import org.connectorio.addons.binding.ocpp.internal.server.OcppChargerSessionRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RemoteAuthorizationConfigAdapter extends CoreEventHandlerAdapter {
+
+  private final Logger logger = LoggerFactory.getLogger(RemoteAuthorizationConfigAdapter.class);
+  private final OcppChargerSessionRegistry sessionRegistry;
+  private final OcppSender sender;
+
+  public RemoteAuthorizationConfigAdapter(OcppChargerSessionRegistry sessionRegistry, OcppSender sender) {
+    this.sessionRegistry = sessionRegistry;
+    this.sender = sender;
+  }
+
+  @Override
+  public BootNotificationConfirmation handleBootNotificationRequest(UUID sessionIndex, BootNotificationRequest request) {
+    ChargerReference reference = sessionRegistry.getCharger(sessionIndex);
+    if (reference == null) {
+      return null;
+    }
+    sender.send(reference, new ChangeConfigurationRequest("AuthorizeRemoteTxRequests", "false"))
+        .whenComplete((confirmation, ex) -> {
+      if (ex != null) {
+        logger.warn("ChangeConfiguration[AuthorizeRemoteTxRequests=false] for {} failed: {}", reference, ex.getMessage());
+      } else {
+        logger.debug("ChangeConfiguration[AuthorizeRemoteTxRequests=false] for {}: {}", reference, confirmation);
+      }
+    });
+    return null;
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -109,6 +109,17 @@
         <unitLabel>s</unitLabel>
         <advanced>true</advanced>
       </parameter>
+      <parameter name="disableRemoteTxAuthorization" type="boolean" required="false">
+        <label>Disable Local Authorization for RemoteStart</label>
+        <description>
+          Push AuthorizeRemoteTxRequests=false to each connecting charger on BootNotification.
+          Chargers like Phoenix Contact CHARX SEC-3xxx ship with AuthorizeRemoteTxRequests=true
+          and an empty local auth list, which Rejects every CSMS-initiated RemoteStartTransaction.
+          Disable only if you rely on the charger's local authorization list.
+        </description>
+        <default>true</default>
+        <advanced>true</advanced>
+      </parameter>
     </config-description>
   </bridge-type>
 


### PR DESCRIPTION
Phoenix Contact CHARX SEC-3xxx (FW 1.9.0) ships with `AuthorizeRemoteTxRequests=true` and an empty local authorization list. Every CSMS-initiated `RemoteStartTransaction` comes back `Rejected` — the `chargingCommand` channel does nothing on a fresh charger until the user pushes `ChangeConfiguration[AuthorizeRemoteTxRequests=false]` by hand. Wallbox Copper SB / Pulsar Plus (FW 6.7.38) accept either value, so they're unaffected.

New `RemoteAuthorizationConfigAdapter` fires `ChangeConfiguration[AuthorizeRemoteTxRequests=false]` on `BootNotification`. Gated by server-bridge config flag `disableRemoteTxAuthorization` (default `true`); disable only if you rely on the charger's local auth list.
