### PR TITLE
Reset power/current channels when charging ends

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -174,6 +174,13 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
     StringType val = new StringType(status.name());
     getCallback().stateUpdated(new ChannelUID(getThing().getUID(), "chargePointStatus"), val);
 
+    if (status == ChargePointStatus.Available
+        || status == ChargePointStatus.Finishing
+        || status == ChargePointStatus.SuspendedEV
+        || status == ChargePointStatus.SuspendedEVSE) {
+      resetPowerAndCurrentChannels();
+    }
+
     return new StatusNotificationConfirmation();
   }
 
@@ -207,7 +214,21 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
     callback.stateUpdated(new ChannelUID(getThing().getUID(), "timestampStop"), new DateTimeType(request.getTimestamp()));
     callback.stateUpdated(new ChannelUID(getThing().getUID(), "meterStop"), new QuantityType<>(request.getMeterStop(), Units.WATT_HOUR));
 
+    resetPowerAndCurrentChannels();
+
     return new StopTransactionConfirmation();
+  }
+  /**
+   * Resets power and current-related channels to 0 when a transaction ends.
+   */
+  private void resetPowerAndCurrentChannels() {
+    ThingHandlerCallback callback = getCallback();
+    callback.stateUpdated(new ChannelUID(getThing().getUID(), OcppBindingConstants.POWER_ACTIVE_IMPORT.getAsString()), new QuantityType<>(0, Units.WATT));
+    callback.stateUpdated(new ChannelUID(getThing().getUID(), OcppBindingConstants.CURRENT_IMPORT.getAsString()), new QuantityType<>(0, Units.AMPERE));
+    callback.stateUpdated(new ChannelUID(getThing().getUID(), OcppBindingConstants.CURRENT_IMPORT_L1.getAsString()), new QuantityType<>(0, Units.AMPERE));
+    callback.stateUpdated(new ChannelUID(getThing().getUID(), OcppBindingConstants.CURRENT_IMPORT_L2.getAsString()), new QuantityType<>(0, Units.AMPERE));
+    callback.stateUpdated(new ChannelUID(getThing().getUID(), OcppBindingConstants.CURRENT_IMPORT_L3.getAsString()), new QuantityType<>(0, Units.AMPERE));
+    callback.stateUpdated(new ChannelUID(getThing().getUID(), OcppBindingConstants.CURRENT_OFFERED.getAsString()), new QuantityType<>(0, Units.AMPERE));
   }
 
   private static State parse(Double measurement, ChannelUID uid, SampledValue sample) {

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -182,7 +182,7 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
         || status == ChargePointStatus.Finishing
         || status == ChargePointStatus.SuspendedEV
         || status == ChargePointStatus.SuspendedEVSE) {
-      resetPowerAndCurrentChannels();
+      resetSessionState(null, null);
     }
 
     return new StatusNotificationConfirmation();
@@ -211,22 +211,28 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
       return new StopTransactionConfirmation();
     }
 
-    currentTransactionId = null;
+    resetSessionState(tag, OnOffType.OFF);
+    // Set stop-specific fields
     ThingHandlerCallback callback = getCallback();
-    callback.stateUpdated(new ChannelUID(getThing().getUID(), "idTag"), new StringType(tag));
-    callback.stateUpdated(new ChannelUID(getThing().getUID(), OcppBindingConstants.CHARGING.getAsString()), OnOffType.OFF);
     callback.stateUpdated(new ChannelUID(getThing().getUID(), "timestampStop"), new DateTimeType(request.getTimestamp()));
     callback.stateUpdated(new ChannelUID(getThing().getUID(), "meterStop"), new QuantityType<>(request.getMeterStop(), Units.WATT_HOUR));
-
-    resetPowerAndCurrentChannels();
 
     return new StopTransactionConfirmation();
   }
   /**
-   * Resets power and current-related channels to 0 when a transaction ends.
+   * Resets all relevant session state and channels when a transaction ends or charger becomes available.
+   * If any argument is null, that field is not updated (for use in StatusNotification events).
    */
-  private void resetPowerAndCurrentChannels() {
+  private void resetSessionState(String idTag, OnOffType chargingState) {
+    currentTransactionId = null;
     ThingHandlerCallback callback = getCallback();
+    if (idTag != null) {
+      callback.stateUpdated(new ChannelUID(getThing().getUID(), "idTag"), new StringType(idTag));
+    }
+    if (chargingState != null) {
+      callback.stateUpdated(new ChannelUID(getThing().getUID(), OcppBindingConstants.CHARGING.getAsString()), chargingState);
+    }
+    // Always reset power/current channels
     callback.stateUpdated(new ChannelUID(getThing().getUID(), OcppBindingConstants.POWER_ACTIVE_IMPORT.getAsString()), new QuantityType<>(0, Units.WATT));
     callback.stateUpdated(new ChannelUID(getThing().getUID(), OcppBindingConstants.CURRENT_IMPORT.getAsString()), new QuantityType<>(0, Units.AMPERE));
     callback.stateUpdated(new ChannelUID(getThing().getUID(), OcppBindingConstants.CURRENT_IMPORT_L1.getAsString()), new QuantityType<>(0, Units.AMPERE));

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -49,6 +49,10 @@ import tech.units.indriya.quantity.Quantities;
 public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeHandler, ConnectorConfig> implements
   StatusNotificationHandler, TransactionHandler, MeterValuesHandler, ConnectorCommandContext {
 
+  // Package-scoped for testability
+  void setTransactionId(int value) {
+    this.transactionId.set(value);
+  }
   private final AtomicInteger transactionId = new AtomicInteger();
   private final Logger logger = LoggerFactory.getLogger(ConnectorThingHandler.class);
 

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandlerTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandlerTest.java
@@ -60,10 +60,10 @@ class ConnectorThingHandlerTest {
 
     private void verifyResetChannels() {
         verify(callback).stateUpdated(new ChannelUID("ocpp:connector:1:powerActiveImport"), new QuantityType<>(0, Units.WATT));
-        verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("currentImport")), eq(new QuantityType<>(0, Units.AMPERE)));
-        verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("currentImportL1")), eq(new QuantityType<>(0, Units.AMPERE)));
-        verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("currentImportL2")), eq(new QuantityType<>(0, Units.AMPERE)));
-        verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("currentImportL3")), eq(new QuantityType<>(0, Units.AMPERE)));
-        verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("currentOffered")), eq(new QuantityType<>(0, Units.AMPERE)));
+        verify(callback).stateUpdated(new ChannelUID("ocpp:connector:1:currentImport"), new QuantityType<>(0, Units.AMPERE));
+        verify(callback).stateUpdated(new ChannelUID("ocpp:connector:1:currentImportL1"), new QuantityType<>(0, Units.AMPERE));
+        verify(callback).stateUpdated(new ChannelUID("ocpp:connector:1:currentImportL2"), new QuantityType<>(0, Units.AMPERE));
+        verify(callback).stateUpdated(new ChannelUID("ocpp:connector:1:currentImportL3"), new QuantityType<>(0, Units.AMPERE));
+        verify(callback).stateUpdated(new ChannelUID("ocpp:connector:1:currentOffered"), new QuantityType<>(0, Units.AMPERE));
     }
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandlerTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandlerTest.java
@@ -3,6 +3,7 @@ package org.connectorio.addons.binding.ocpp.internal.handler;
 import eu.chargetime.ocpp.model.core.ChargePointStatus;
 import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
 import eu.chargetime.ocpp.model.core.StopTransactionRequest;
+import java.time.ZonedDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -36,16 +37,7 @@ class ConnectorThingHandlerTest {
         StopTransactionRequest request = new StopTransactionRequest(0, ZonedDateTime.now(), 1);
         request.setIdTag("testTag");
         // Simulate transactionId state
-        java.lang.reflect.Field txIdField;
-        try {
-            txIdField = ConnectorThingHandler.class.getDeclaredField("transactionId");
-            txIdField.setAccessible(true);
-            java.util.concurrent.atomic.AtomicInteger txId = new java.util.concurrent.atomic.AtomicInteger(0);
-            txId.set(2); // so txId.get() == 2, request.getTransactionId() == 1
-            txIdField.set(handler, txId);
-        } catch (Exception e) {
-            fail(e);
-        }
+        handler.setTransactionId(2); // so transactionId.get() == 2, request.getTransactionId() == 1
         handler.handleStopTransaction(request);
         verifyResetChannels();
     }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandlerTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandlerTest.java
@@ -1,0 +1,80 @@
+package org.connectorio.addons.binding.ocpp.internal.handler;
+
+import eu.chargetime.ocpp.model.core.ChargePointStatus;
+import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
+import eu.chargetime.ocpp.model.core.StopTransactionRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+import tech.units.indriya.unit.Units;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ConnectorThingHandlerTest {
+
+    private ConnectorThingHandler handler;
+    private ThingHandlerCallback callback;
+    private Thing thing;
+
+    @BeforeEach
+    void setUp() {
+        thing = mock(Thing.class);
+        when(thing.getUID()).thenReturn(new ThingUID("ocpp:connector:1"));
+        handler = new ConnectorThingHandler(thing);
+        callback = mock(ThingHandlerCallback.class);
+        handler.setCallback(callback);
+    }
+
+    @Test
+    void testResetOnStopTransaction() {
+        StopTransactionRequest request = mock(StopTransactionRequest.class);
+        when(request.getIdTag()).thenReturn("testTag");
+        when(request.getTransactionId()).thenReturn(1);
+        when(request.getTimestamp()).thenReturn(java.time.ZonedDateTime.now());
+        when(request.getMeterStop()).thenReturn(0);
+        // Simulate transactionId state
+        java.lang.reflect.Field txIdField;
+        try {
+            txIdField = ConnectorThingHandler.class.getDeclaredField("transactionId");
+            txIdField.setAccessible(true);
+            java.util.concurrent.atomic.AtomicInteger txId = new java.util.concurrent.atomic.AtomicInteger(0);
+            txId.set(2); // so txId.get() == 2, request.getTransactionId() == 1
+            txIdField.set(handler, txId);
+        } catch (Exception e) {
+            fail(e);
+        }
+        handler.handleStopTransaction(request);
+        verifyResetChannels();
+    }
+
+    @Test
+    void testResetOnStatusNotificationAvailable() {
+        StatusNotificationRequest request = mock(StatusNotificationRequest.class);
+        when(request.getStatus()).thenReturn(ChargePointStatus.Available);
+        handler.handleStatusNotification(request);
+        verifyResetChannels();
+    }
+
+    @Test
+    void testResetOnStatusNotificationFinishing() {
+        StatusNotificationRequest request = mock(StatusNotificationRequest.class);
+        when(request.getStatus()).thenReturn(ChargePointStatus.Finishing);
+        handler.handleStatusNotification(request);
+        verifyResetChannels();
+    }
+
+    private void verifyResetChannels() {
+        verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("powerActiveImport")), eq(new QuantityType<>(0, Units.WATT)));
+        verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("currentImport")), eq(new QuantityType<>(0, Units.AMPERE)));
+        verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("currentImportL1")), eq(new QuantityType<>(0, Units.AMPERE)));
+        verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("currentImportL2")), eq(new QuantityType<>(0, Units.AMPERE)));
+        verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("currentImportL3")), eq(new QuantityType<>(0, Units.AMPERE)));
+        verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("currentOffered")), eq(new QuantityType<>(0, Units.AMPERE)));
+    }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandlerTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandlerTest.java
@@ -33,11 +33,8 @@ class ConnectorThingHandlerTest {
 
     @Test
     void testResetOnStopTransaction() {
-        StopTransactionRequest request = mock(StopTransactionRequest.class);
-        when(request.getIdTag()).thenReturn("testTag");
-        when(request.getTransactionId()).thenReturn(1);
-        when(request.getTimestamp()).thenReturn(java.time.ZonedDateTime.now());
-        when(request.getMeterStop()).thenReturn(0);
+        StopTransactionRequest request = new StopTransactionRequest(0, ZonedDateTime.now(), 1);
+        request.setIdTag("testTag");
         // Simulate transactionId state
         java.lang.reflect.Field txIdField;
         try {
@@ -70,7 +67,7 @@ class ConnectorThingHandlerTest {
     }
 
     private void verifyResetChannels() {
-        verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("powerActiveImport")), eq(new QuantityType<>(0, Units.WATT)));
+        verify(callback).stateUpdated(new ChannelUID("ocpp:connector:1:powerActiveImport"), new QuantityType<>(0, Units.WATT));
         verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("currentImport")), eq(new QuantityType<>(0, Units.AMPERE)));
         verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("currentImportL1")), eq(new QuantityType<>(0, Units.AMPERE)));
         verify(callback).stateUpdated(argThat(uid -> uid.getId().equals("currentImportL2")), eq(new QuantityType<>(0, Units.AMPERE)));


### PR DESCRIPTION
When I stop charging on the EV app, the power/current values remain at their latest values because the charger stops sending the measurements when charging stops. The proposed change sets these values to 0 on stop charging.