### PR TITLE
[ocpp] Configurable vendor keys pushed on BootNotification

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ServerConfig.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ServerConfig.java
@@ -33,6 +33,7 @@ public class ServerConfig implements Configuration {
   public String meterValuesData = "Energy.Active.Import.Register,Power.Active.Import,Current.Import,Voltage";
   public int clockAlignedDataInterval = 30;
   public boolean disableRemoteTxAuthorization = true;
+  public List<String> vendorConfig;
 
   public List<String> chargers;
   public List<String> tags;

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ServerBridgeHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ServerBridgeHandler.java
@@ -44,6 +44,7 @@ import org.connectorio.addons.binding.ocpp.internal.server.adapter.BootRegistrat
 import org.connectorio.addons.binding.ocpp.internal.server.adapter.MeterValuesConfigAdapter;
 import org.connectorio.addons.binding.ocpp.internal.server.adapter.RemoteAuthorizationConfigAdapter;
 import org.connectorio.addons.binding.ocpp.internal.server.adapter.RequestListenerAdapter;
+import org.connectorio.addons.binding.ocpp.internal.server.adapter.VendorConfigAdapter;
 import org.connectorio.addons.binding.ocpp.internal.server.custom.OcularSolarEcoMode;
 import org.openhab.core.net.NetworkAddressService;
 import org.openhab.core.thing.Bridge;
@@ -110,6 +111,7 @@ public class ServerBridgeHandler extends GenericBridgeHandlerBase<ServerConfig> 
     if (config.disableRemoteTxAuthorization) {
       eventHandlers.addFirst(new RemoteAuthorizationConfigAdapter(bootAdapter, server));
     }
+    eventHandlers.addFirst(new VendorConfigAdapter(bootAdapter, server, VendorConfigAdapter.parse(config.vendorConfig)));
     server.activate();
     updateStatus(ThingStatus.ONLINE);
   }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/VendorConfigAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/VendorConfigAdapter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2022-2022 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.binding.ocpp.internal.server.adapter;
+
+import eu.chargetime.ocpp.model.core.BootNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.BootNotificationRequest;
+import eu.chargetime.ocpp.model.core.ChangeConfigurationRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.connectorio.addons.binding.ocpp.internal.OcppSender;
+import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
+import org.connectorio.addons.binding.ocpp.internal.server.OcppChargerSessionRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class VendorConfigAdapter extends CoreEventHandlerAdapter {
+
+  private final Logger logger = LoggerFactory.getLogger(VendorConfigAdapter.class);
+  private final OcppChargerSessionRegistry sessionRegistry;
+  private final OcppSender sender;
+  private final Map<String, String> vendorKeys;
+
+  public VendorConfigAdapter(OcppChargerSessionRegistry sessionRegistry, OcppSender sender,
+      Map<String, String> vendorKeys) {
+    this.sessionRegistry = sessionRegistry;
+    this.sender = sender;
+    this.vendorKeys = vendorKeys;
+  }
+
+  @Override
+  public BootNotificationConfirmation handleBootNotificationRequest(UUID sessionIndex, BootNotificationRequest request) {
+    if (vendorKeys == null || vendorKeys.isEmpty()) {
+      return null;
+    }
+    ChargerReference reference = sessionRegistry.getCharger(sessionIndex);
+    if (reference == null) {
+      return null;
+    }
+    for (Map.Entry<String, String> entry : vendorKeys.entrySet()) {
+      apply(reference, entry.getKey(), entry.getValue());
+    }
+    return null;
+  }
+
+  private void apply(ChargerReference reference, String key, String value) {
+    sender.send(reference, new ChangeConfigurationRequest(key, value)).whenComplete((confirmation, ex) -> {
+      if (ex != null) {
+        logger.warn("ChangeConfiguration[{}={}] for {} failed: {}", key, value, reference, ex.getMessage());
+      } else {
+        logger.debug("ChangeConfiguration[{}={}] for {}: {}", key, value, reference, confirmation);
+      }
+    });
+  }
+
+  /**
+   * Parse a list of {@code key=value} strings into a map. Empty entries and entries without
+   * {@code =} are ignored. Whitespace around key and value is trimmed.
+   */
+  public static Map<String, String> parse(List<String> entries) {
+    Map<String, String> map = new java.util.LinkedHashMap<>();
+    if (entries == null) {
+      return map;
+    }
+    for (String entry : entries) {
+      if (entry == null) {
+        continue;
+      }
+      int eq = entry.indexOf('=');
+      if (eq <= 0 || eq == entry.length() - 1) {
+        continue;
+      }
+      String key = entry.substring(0, eq).trim();
+      String value = entry.substring(eq + 1).trim();
+      if (!key.isEmpty()) {
+        map.put(key, value);
+      }
+    }
+    return map;
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -120,6 +120,17 @@
         <default>true</default>
         <advanced>true</advanced>
       </parameter>
+      <parameter name="vendorConfig" type="text" required="false" multiple="true">
+        <label>Vendor Configuration Keys</label>
+        <description>
+          Vendor-specific OCPP configuration keys to push as ChangeConfiguration on each charger's
+          BootNotification. Format: KEY=VALUE per entry. Example: FreeMode=true (Phoenix Contact CHARX
+          authorisation bypass; AuthorizeRemoteTxRequests=false alone is not enough on CHARX SEC-3xxx
+          FW 1.9.0 to accept CSMS-initiated RemoteStartTransaction). Chargers that don't recognise a
+          key respond NotSupported and the entry is logged.
+        </description>
+        <advanced>true</advanced>
+      </parameter>
     </config-description>
   </bridge-type>
 


### PR DESCRIPTION
Some chargers gate CSMS-initiated `RemoteStartTransaction` behind a vendor-specific configuration key that's outside OCPP 1.6 Core. Phoenix Contact CHARX SEC-3xxx (FW 1.9.0) requires `FreeMode=true` *in addition to* `AuthorizeRemoteTxRequests=false` — without `FreeMode` the charger still returns `Rejected` for every CSMS-initiated `RemoteStart`. Wallbox Copper SB / Pulsar Plus (FW 6.7.38) don't recognise the key and respond `NotSupported`, which is harmless.

New `VendorConfigAdapter` takes a `Map<String,String>` populated from a new server-bridge config `vendorConfig` (list of `KEY=VALUE` entries, advanced) and fires one `ChangeConfiguration` per entry on each `BootNotification`. Generic — usable for any charger that needs vendor-specific bootstrap config beyond the OCPP Core profile.
