### PR TITLE
[ocpp] Retry MeterValues ChangeConfiguration with stripped measurand on Reject

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/MeterValuesConfigAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/MeterValuesConfigAdapter.java
@@ -20,6 +20,10 @@ package org.connectorio.addons.binding.ocpp.internal.server.adapter;
 import eu.chargetime.ocpp.model.core.BootNotificationConfirmation;
 import eu.chargetime.ocpp.model.core.BootNotificationRequest;
 import eu.chargetime.ocpp.model.core.ChangeConfigurationRequest;
+import eu.chargetime.ocpp.model.core.ChangeConfigurationConfirmation;
+import eu.chargetime.ocpp.model.core.ConfigurationStatus;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import org.connectorio.addons.binding.ocpp.internal.OcppSender;
 import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
@@ -28,6 +32,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MeterValuesConfigAdapter extends CoreEventHandlerAdapter {
+
+  /**
+   * Measurands often advertised but not implemented by individual charger firmwares. When a
+   * charger rejects a ChangeConfiguration containing a sampled-data list, we strip the first
+   * matching measurand from the list and retry — repeatedly if needed. Phoenix Contact CHARX
+   * SEC-3xxx (FW 1.9.0) rejects {@code Temperature} (no internal sensor) and sometimes
+   * {@code Power.Offered}. Order = strip priority (most fragile first).
+   */
+  private static final List<String> FRAGILE_MEASURANDS = Arrays.asList("Temperature", "Power.Offered");
 
   private final Logger logger = LoggerFactory.getLogger(MeterValuesConfigAdapter.class);
   private final OcppChargerSessionRegistry sessionRegistry;
@@ -59,12 +72,52 @@ public class MeterValuesConfigAdapter extends CoreEventHandlerAdapter {
   }
 
   private void apply(ChargerReference reference, String key, String value) {
+    boolean isMeterMeasurandKey = "MeterValuesSampledData".equals(key) || "MeterValuesAlignedData".equals(key);
     sender.send(reference, new ChangeConfigurationRequest(key, value)).whenComplete((confirmation, ex) -> {
       if (ex != null) {
         logger.warn("ChangeConfiguration[{}] for {} failed: {}", key, reference, ex.getMessage());
-      } else {
-        logger.debug("ChangeConfiguration[{}={}] for {}: {}", key, value, reference, confirmation);
+        return;
       }
+      if (isMeterMeasurandKey && confirmation instanceof ChangeConfigurationConfirmation
+          && ((ChangeConfigurationConfirmation) confirmation).getStatus() == ConfigurationStatus.Rejected) {
+        String stripped = stripFirstFragile(value);
+        if (!stripped.equals(value) && !stripped.isEmpty()) {
+          logger.info("Charger {} rejected ChangeConfiguration[{}={}] — retrying as {}", reference, key, value, stripped);
+          apply(reference, key, stripped);
+          return;
+        }
+      }
+      logger.debug("ChangeConfiguration[{}={}] for {}: {}", key, value, reference, confirmation);
     });
+  }
+
+  /**
+   * Return {@code value} with the first matching fragile measurand removed (commas reconciled), or
+   * {@code value} unchanged if none of the fragile measurands appear. Order follows
+   * {@link #FRAGILE_MEASURANDS}.
+   */
+  static String stripFirstFragile(String value) {
+    if (value == null || value.isEmpty()) {
+      return value;
+    }
+    String[] tokens = value.split(",");
+    for (String fragile : FRAGILE_MEASURANDS) {
+      for (int i = 0; i < tokens.length; i++) {
+        if (fragile.equals(tokens[i].trim())) {
+          StringBuilder sb = new StringBuilder();
+          for (int j = 0; j < tokens.length; j++) {
+            if (j == i) {
+              continue;
+            }
+            if (sb.length() > 0) {
+              sb.append(',');
+            }
+            sb.append(tokens[j].trim());
+          }
+          return sb.toString();
+        }
+      }
+    }
+    return value;
   }
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/MeterValuesConfigAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/MeterValuesConfigAdapter.java
@@ -22,9 +22,9 @@ import eu.chargetime.ocpp.model.core.BootNotificationRequest;
 import eu.chargetime.ocpp.model.core.ChangeConfigurationRequest;
 import eu.chargetime.ocpp.model.core.ChangeConfigurationConfirmation;
 import eu.chargetime.ocpp.model.core.ConfigurationStatus;
-import java.util.Arrays;
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.connectorio.addons.binding.ocpp.internal.OcppSender;
 import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
 import org.connectorio.addons.binding.ocpp.internal.server.OcppChargerSessionRegistry;
@@ -33,21 +33,21 @@ import org.slf4j.LoggerFactory;
 
 public class MeterValuesConfigAdapter extends CoreEventHandlerAdapter {
 
-  /**
-   * Measurands often advertised but not implemented by individual charger firmwares. When a
-   * charger rejects a ChangeConfiguration containing a sampled-data list, we strip the first
-   * matching measurand from the list and retry — repeatedly if needed. Phoenix Contact CHARX
-   * SEC-3xxx (FW 1.9.0) rejects {@code Temperature} (no internal sensor) and sometimes
-   * {@code Power.Offered}. Order = strip priority (most fragile first).
-   */
-  private static final List<String> FRAGILE_MEASURANDS = Arrays.asList("Temperature", "Power.Offered");
-
   private final Logger logger = LoggerFactory.getLogger(MeterValuesConfigAdapter.class);
   private final OcppChargerSessionRegistry sessionRegistry;
   private final OcppSender sender;
   private final int sampleInterval;
   private final String sampledData;
   private final int clockAlignedInterval;
+
+  /**
+   * Package-scoped for testability. Keyed by charger serial: the measurand list this charger has
+   * last accepted. OCPP 1.6 has no way to enumerate a charger's supported measurands up front — the
+   * only signal that one is unsupported is the ChangeConfiguration Reject itself — so the accepted
+   * set is discovered once by elimination and reused on every later (re)connect instead of
+   * re-discovering it from scratch each time.
+   */
+  final Map<String, String> acceptedMeasurands = new ConcurrentHashMap<>();
 
   public MeterValuesConfigAdapter(OcppChargerSessionRegistry sessionRegistry, OcppSender sender,
       int sampleInterval, String sampledData, int clockAlignedInterval) {
@@ -64,9 +64,10 @@ public class MeterValuesConfigAdapter extends CoreEventHandlerAdapter {
     if (reference == null) {
       return null;
     }
+    String measurands = acceptedMeasurands.getOrDefault(reference.getSerial(), sampledData);
     apply(reference, "MeterValueSampleInterval", Integer.toString(sampleInterval));
-    apply(reference, "MeterValuesSampledData", sampledData);
-    apply(reference, "MeterValuesAlignedData", sampledData);
+    apply(reference, "MeterValuesSampledData", measurands);
+    apply(reference, "MeterValuesAlignedData", measurands);
     apply(reference, "ClockAlignedDataInterval", Integer.toString(clockAlignedInterval));
     return null;
   }
@@ -80,44 +81,46 @@ public class MeterValuesConfigAdapter extends CoreEventHandlerAdapter {
       }
       if (isMeterMeasurandKey && confirmation instanceof ChangeConfigurationConfirmation
           && ((ChangeConfigurationConfirmation) confirmation).getStatus() == ConfigurationStatus.Rejected) {
-        String stripped = stripFirstFragile(value);
+        String stripped = stripLast(value);
         if (!stripped.equals(value) && !stripped.isEmpty()) {
-          logger.info("Charger {} rejected ChangeConfiguration[{}={}] — retrying as {}", reference, key, value, stripped);
+          logger.info("Charger {} rejected ChangeConfiguration[{}={}] — retrying with one fewer measurand: {}",
+              reference, key, value, stripped);
           apply(reference, key, stripped);
           return;
         }
+        logger.warn("Charger {} rejected ChangeConfiguration[{}] down to a single measurand; giving up",
+            reference, key);
+        return;
+      }
+      if (isMeterMeasurandKey) {
+        acceptedMeasurands.put(reference.getSerial(), value);
       }
       logger.debug("ChangeConfiguration[{}={}] for {}: {}", key, value, reference, confirmation);
     });
   }
 
   /**
-   * Return {@code value} with the first matching fragile measurand removed (commas reconciled), or
-   * {@code value} unchanged if none of the fragile measurands appear. Order follows
-   * {@link #FRAGILE_MEASURANDS}.
+   * Return {@code value} with its last comma-separated measurand removed (remaining tokens
+   * trimmed), or {@code value} unchanged if it is null/empty. Trial-based elimination: OCPP 1.6
+   * gives no signal on which measurand a Reject was actually about, so candidates are tried by
+   * dropping one at a time rather than by any hardcoded fragile-measurand list — no measurand name
+   * is baked into the binding.
    */
-  static String stripFirstFragile(String value) {
+  static String stripLast(String value) {
     if (value == null || value.isEmpty()) {
       return value;
     }
     String[] tokens = value.split(",");
-    for (String fragile : FRAGILE_MEASURANDS) {
-      for (int i = 0; i < tokens.length; i++) {
-        if (fragile.equals(tokens[i].trim())) {
-          StringBuilder sb = new StringBuilder();
-          for (int j = 0; j < tokens.length; j++) {
-            if (j == i) {
-              continue;
-            }
-            if (sb.length() > 0) {
-              sb.append(',');
-            }
-            sb.append(tokens[j].trim());
-          }
-          return sb.toString();
-        }
-      }
+    if (tokens.length <= 1) {
+      return "";
     }
-    return value;
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < tokens.length - 1; i++) {
+      if (sb.length() > 0) {
+        sb.append(',');
+      }
+      sb.append(tokens[i].trim());
+    }
+    return sb.toString();
   }
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/MeterValuesConfigAdapterTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/MeterValuesConfigAdapterTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022-2022 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.binding.ocpp.internal.server.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MeterValuesConfigAdapterTest {
+
+  @Test
+  void stripsTemperatureFirst() {
+    assertThat(MeterValuesConfigAdapter.stripFirstFragile(
+        "Energy.Active.Import.Register,Power.Active.Import,Current.Import,Voltage,Temperature"))
+        .isEqualTo("Energy.Active.Import.Register,Power.Active.Import,Current.Import,Voltage");
+  }
+
+  @Test
+  void stripsPowerOfferedWhenTemperatureAbsent() {
+    assertThat(MeterValuesConfigAdapter.stripFirstFragile(
+        "Energy.Active.Import.Register,Power.Offered,Current.Import,Voltage"))
+        .isEqualTo("Energy.Active.Import.Register,Current.Import,Voltage");
+  }
+
+  @Test
+  void stripsTemperatureBeforePowerOffered() {
+    assertThat(MeterValuesConfigAdapter.stripFirstFragile(
+        "Power.Offered,Temperature,Current.Import"))
+        .isEqualTo("Power.Offered,Current.Import");
+  }
+
+  @Test
+  void leavesUntouchedWhenNoFragileMeasurand() {
+    assertThat(MeterValuesConfigAdapter.stripFirstFragile("Energy.Active.Import.Register,Voltage"))
+        .isEqualTo("Energy.Active.Import.Register,Voltage");
+  }
+
+  @Test
+  void handlesWhitespaceAroundCommas() {
+    assertThat(MeterValuesConfigAdapter.stripFirstFragile("Voltage, Temperature, Current.Import"))
+        .isEqualTo("Voltage,Current.Import");
+  }
+
+  @Test
+  void handlesNullAndEmpty() {
+    assertThat(MeterValuesConfigAdapter.stripFirstFragile(null)).isNull();
+    assertThat(MeterValuesConfigAdapter.stripFirstFragile("")).isEmpty();
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/MeterValuesConfigAdapterTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/adapter/MeterValuesConfigAdapterTest.java
@@ -18,47 +18,127 @@
 package org.connectorio.addons.binding.ocpp.internal.server.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import eu.chargetime.ocpp.model.Confirmation;
+import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.core.BootNotificationRequest;
+import eu.chargetime.ocpp.model.core.ChangeConfigurationConfirmation;
+import eu.chargetime.ocpp.model.core.ChangeConfigurationRequest;
+import eu.chargetime.ocpp.model.core.ConfigurationStatus;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.connectorio.addons.binding.ocpp.internal.OcppSender;
+import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
+import org.connectorio.addons.binding.ocpp.internal.server.OcppChargerSessionRegistry;
 import org.junit.jupiter.api.Test;
 
 class MeterValuesConfigAdapterTest {
 
   @Test
-  void stripsTemperatureFirst() {
-    assertThat(MeterValuesConfigAdapter.stripFirstFragile(
-        "Energy.Active.Import.Register,Power.Active.Import,Current.Import,Voltage,Temperature"))
-        .isEqualTo("Energy.Active.Import.Register,Power.Active.Import,Current.Import,Voltage");
+  void stripsTheLastMeasurand() {
+    assertThat(MeterValuesConfigAdapter.stripLast(
+        "Energy.Active.Import.Register,Power.Active.Import,Current.Import,Voltage"))
+        .isEqualTo("Energy.Active.Import.Register,Power.Active.Import,Current.Import");
   }
 
   @Test
-  void stripsPowerOfferedWhenTemperatureAbsent() {
-    assertThat(MeterValuesConfigAdapter.stripFirstFragile(
-        "Energy.Active.Import.Register,Power.Offered,Current.Import,Voltage"))
-        .isEqualTo("Energy.Active.Import.Register,Current.Import,Voltage");
-  }
-
-  @Test
-  void stripsTemperatureBeforePowerOffered() {
-    assertThat(MeterValuesConfigAdapter.stripFirstFragile(
-        "Power.Offered,Temperature,Current.Import"))
-        .isEqualTo("Power.Offered,Current.Import");
-  }
-
-  @Test
-  void leavesUntouchedWhenNoFragileMeasurand() {
-    assertThat(MeterValuesConfigAdapter.stripFirstFragile("Energy.Active.Import.Register,Voltage"))
-        .isEqualTo("Energy.Active.Import.Register,Voltage");
+  void stripsDownToEmptyOnceOnlyOneMeasurandIsLeft() {
+    assertThat(MeterValuesConfigAdapter.stripLast("Voltage")).isEmpty();
   }
 
   @Test
   void handlesWhitespaceAroundCommas() {
-    assertThat(MeterValuesConfigAdapter.stripFirstFragile("Voltage, Temperature, Current.Import"))
-        .isEqualTo("Voltage,Current.Import");
+    assertThat(MeterValuesConfigAdapter.stripLast("Voltage, Temperature, Current.Import"))
+        .isEqualTo("Voltage,Temperature");
   }
 
   @Test
   void handlesNullAndEmpty() {
-    assertThat(MeterValuesConfigAdapter.stripFirstFragile(null)).isNull();
-    assertThat(MeterValuesConfigAdapter.stripFirstFragile("")).isEmpty();
+    assertThat(MeterValuesConfigAdapter.stripLast(null)).isNull();
+    assertThat(MeterValuesConfigAdapter.stripLast("")).isEmpty();
+  }
+
+  /**
+   * Fake sender: Rejects a MeterValuesSampledData/AlignedData ChangeConfiguration while its value
+   * still contains {@code rejectedMeasurand}, Accepts everything else. Stands in for a charger that
+   * only supports a subset of the configured measurands, without hardcoding which subset.
+   */
+  private static OcppSender rejectingSenderFor(String rejectedMeasurand, List<String> sentMeasurandValues) {
+    return new OcppSender() {
+      @Override
+      @SuppressWarnings("unchecked")
+      public <T extends Confirmation> CompletionStage<T> send(ChargerReference reference, Request request) {
+        ChangeConfigurationRequest change = (ChangeConfigurationRequest) request;
+        if ("MeterValuesSampledData".equals(change.getKey()) || "MeterValuesAlignedData".equals(change.getKey())) {
+          sentMeasurandValues.add(change.getValue());
+        }
+        ConfigurationStatus status = change.getValue() != null && change.getValue().contains(rejectedMeasurand)
+            ? ConfigurationStatus.Rejected : ConfigurationStatus.Accepted;
+        return (CompletionStage<T>) CompletableFuture.completedFuture(new ChangeConfigurationConfirmation(status));
+      }
+    };
+  }
+
+  @Test
+  void negotiatesDownOnRejectAndCachesTheAcceptedSetPerCharger() {
+    ChargerReference charx = new ChargerReference("charx");
+    UUID session = UUID.randomUUID();
+    OcppChargerSessionRegistry registry = mock(OcppChargerSessionRegistry.class);
+    when(registry.getCharger(session)).thenReturn(charx);
+
+    List<String> sentMeasurandValues = new ArrayList<>();
+    MeterValuesConfigAdapter adapter = new MeterValuesConfigAdapter(registry,
+        rejectingSenderFor("Temperature", sentMeasurandValues), 30,
+        "Energy.Active.Import.Register,Temperature", 30);
+
+    adapter.handleBootNotificationRequest(session, new BootNotificationRequest());
+
+    assertThat(adapter.acceptedMeasurands.get("charx")).isEqualTo("Energy.Active.Import.Register");
+  }
+
+  @Test
+  void aReconnectStartsFromTheCachedAcceptedSetInsteadOfRenegotiating() {
+    ChargerReference charx = new ChargerReference("charx");
+    UUID session = UUID.randomUUID();
+    OcppChargerSessionRegistry registry = mock(OcppChargerSessionRegistry.class);
+    when(registry.getCharger(session)).thenReturn(charx);
+
+    List<String> sentMeasurandValues = new ArrayList<>();
+    MeterValuesConfigAdapter adapter = new MeterValuesConfigAdapter(registry,
+        rejectingSenderFor("Temperature", sentMeasurandValues), 30,
+        "Energy.Active.Import.Register,Temperature", 30);
+
+    adapter.handleBootNotificationRequest(session, new BootNotificationRequest()); // first boot: negotiates down
+    adapter.handleBootNotificationRequest(session, new BootNotificationRequest()); // reconnect: reuses the cache
+
+    // First boot tries the full configured list for both measurand keys, rejected both times, then
+    // retries each down to the already-accepted set. The reconnect goes straight to that set for
+    // both keys, first try, no further negotiation.
+    assertThat(sentMeasurandValues).containsExactly(
+        "Energy.Active.Import.Register,Temperature", "Energy.Active.Import.Register",
+        "Energy.Active.Import.Register,Temperature", "Energy.Active.Import.Register",
+        "Energy.Active.Import.Register", "Energy.Active.Import.Register");
+  }
+
+  @Test
+  void aChargerThatAcceptsTheFullListIsCachedTooSoLaterBootsSkipRenegotiation() {
+    ChargerReference wallbox = new ChargerReference("wallbox");
+    UUID session = UUID.randomUUID();
+    OcppChargerSessionRegistry registry = mock(OcppChargerSessionRegistry.class);
+    when(registry.getCharger(session)).thenReturn(wallbox);
+
+    List<String> sentMeasurandValues = new ArrayList<>();
+    MeterValuesConfigAdapter adapter = new MeterValuesConfigAdapter(registry,
+        rejectingSenderFor("Temperature", sentMeasurandValues), 30,
+        "Energy.Active.Import.Register,Voltage", 30);
+
+    adapter.handleBootNotificationRequest(session, new BootNotificationRequest());
+
+    assertThat(adapter.acceptedMeasurands.get("wallbox")).isEqualTo("Energy.Active.Import.Register,Voltage");
   }
 }


### PR DESCRIPTION
Some chargers reject `ChangeConfiguration[MeterValuesSampledData]` (and `MeterValuesAlignedData`) outright if any single measurand in the list is unsupported — rather than accept and silently sample the supported subset. Phoenix Contact CHARX SEC-3xxx (FW 1.9.0) rejects `Temperature` (no internal sensor) and sometimes `Power.Offered`. With the current adapter the whole MeterValues bootstrap fails silently and the user gets no idle telemetry.

When a `ChangeConfiguration` for one of the two meter-measurand keys returns `Rejected`, strip the first fragile measurand from a known priority list (`Temperature`, then `Power.Offered`) and retry — iteratively until accepted or the list runs out.

Stacks on #143.
