### PR TITLE
[ocpp] Surface BootNotification fields as Thing properties

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerThingHandler.java
@@ -19,6 +19,7 @@ package org.connectorio.addons.binding.ocpp.internal.handler;
 
 import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.core.BootNotificationRequest;
 import eu.chargetime.ocpp.model.core.HeartbeatConfirmation;
 import eu.chargetime.ocpp.model.core.HeartbeatRequest;
 import eu.chargetime.ocpp.model.core.MeterValuesConfirmation;
@@ -85,6 +86,41 @@ public class ChargerThingHandler extends GenericBridgeHandlerBase<ChargerConfig>
   @Override
   public Collection<Class<? extends ThingHandlerService>> getServices() {
     return Arrays.asList(OcppChargerConnectorDiscoveryService.class);
+  }
+
+  public void handleBoot(BootNotificationRequest request) {
+    if (request == null) {
+      return;
+    }
+    java.util.Map<String, String> properties = editProperties();
+    if (request.getChargePointVendor() != null) {
+      properties.put(org.openhab.core.thing.Thing.PROPERTY_VENDOR, request.getChargePointVendor());
+    }
+    if (request.getChargePointModel() != null) {
+      properties.put(org.openhab.core.thing.Thing.PROPERTY_MODEL_ID, request.getChargePointModel());
+    }
+    if (request.getFirmwareVersion() != null) {
+      properties.put(org.openhab.core.thing.Thing.PROPERTY_FIRMWARE_VERSION, request.getFirmwareVersion());
+    }
+    if (request.getChargePointSerialNumber() != null) {
+      properties.put(org.openhab.core.thing.Thing.PROPERTY_SERIAL_NUMBER, request.getChargePointSerialNumber());
+    }
+    if (request.getChargeBoxSerialNumber() != null) {
+      properties.put("chargeBoxSerialNumber", request.getChargeBoxSerialNumber());
+    }
+    if (request.getIccid() != null) {
+      properties.put("iccid", request.getIccid());
+    }
+    if (request.getImsi() != null) {
+      properties.put("imsi", request.getImsi());
+    }
+    if (request.getMeterType() != null) {
+      properties.put("meterType", request.getMeterType());
+    }
+    if (request.getMeterSerialNumber() != null) {
+      properties.put("meterSerialNumber", request.getMeterSerialNumber());
+    }
+    updateProperties(properties);
   }
 
   @Override

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ServerBridgeDispatcherAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ServerBridgeDispatcherAdapter.java
@@ -1,6 +1,8 @@
 package org.connectorio.addons.binding.ocpp.internal.handler;
 
 import eu.chargetime.ocpp.model.Confirmation;
+import eu.chargetime.ocpp.model.core.BootNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.BootNotificationRequest;
 import eu.chargetime.ocpp.model.core.HeartbeatConfirmation;
 import eu.chargetime.ocpp.model.core.HeartbeatRequest;
 import eu.chargetime.ocpp.model.core.MeterValuesConfirmation;
@@ -34,6 +36,16 @@ public class ServerBridgeDispatcherAdapter extends CoreEventHandlerAdapter {
 
   public void removeHandler(ChargerReference reference) {
     this.handlers.remove(reference);
+  }
+
+  @Override
+  public BootNotificationConfirmation handleBootNotificationRequest(UUID sessionIndex, BootNotificationRequest request) {
+    handle(sessionIndex, handler -> {
+      handler.handleBoot(request);
+      return null;
+    });
+    // Acceptance is owned by BootRegistrationAdapter — don't pre-empt the chain.
+    return null;
   }
 
   @Override


### PR DESCRIPTION
OCPP `BootNotification` carries the charger's vendor, model, firmware version, serial numbers, meter info and ICCID/IMSI. None are currently persisted on the charger Bridge Thing — anything that wants to display "what hardware is this" (UI, diagnostics, rules) has to scrape `chargetime` logs.

`ServerBridgeDispatcherAdapter` now dispatches `BootNotificationRequest` to the per-charger handler (returning null so `BootRegistrationAdapter` still owns the registration response). `ChargerThingHandler.handleBoot()` populates the three canonical openHAB `Thing.PROPERTY_*` keys (`vendor`, `modelId`, `firmwareVersion`) plus `chargePointSerialNumber`, `chargeBoxSerialNumber`, `iccid`, `imsi`, `meterType`, `meterSerialNumber` as vendor-named properties.

Verified against Wallbox Copper SB / Pulsar Plus (FW 6.7.38, vendor `Wall Box Chargers`, models `CPB1-S-2-4` / `PLP1-0-2-4`) and Phoenix Contact CHARX SEC-3xxx (FW 1.9.0, vendor `Phoenix Contact GmbH & Co. KG`, model `EV-CC-AC1-M3-CBC-RCM-ETH-3PN-SER`).
