### PR TITLE
[ocpp] Detect and recover phantom connector cycles

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -1,6 +1,8 @@
 package org.connectorio.addons.binding.ocpp.internal.handler;
 
 import eu.chargetime.ocpp.model.core.AuthorizationStatus;
+import eu.chargetime.ocpp.model.core.AvailabilityType;
+import eu.chargetime.ocpp.model.core.ChangeAvailabilityRequest;
 import eu.chargetime.ocpp.model.core.ChargePointStatus;
 import eu.chargetime.ocpp.model.core.IdTagInfo;
 import eu.chargetime.ocpp.model.core.MeterValue;
@@ -19,12 +21,14 @@ import eu.chargetime.ocpp.model.core.UnlockConnectorRequest;
 import eu.chargetime.ocpp.model.core.ValueFormat;
 import java.time.ZonedDateTime;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.measure.Quantity;
 import org.connectorio.addons.binding.handler.GenericThingHandlerBase;
 import org.connectorio.addons.binding.ocpp.OcppBindingConstants;
 import org.connectorio.addons.binding.ocpp.internal.config.ConnectorConfig;
 import org.connectorio.addons.binding.ocpp.internal.server.OcppMeasurementMapping;
+import org.connectorio.addons.binding.ocpp.internal.server.PhantomCycleDetector;
 import org.connectorio.addons.binding.ocpp.internal.server.listener.MeterValuesHandler;
 import org.connectorio.addons.binding.ocpp.internal.server.listener.StatusNotificationHandler;
 import org.connectorio.addons.binding.ocpp.internal.server.listener.TransactionHandler;
@@ -59,8 +63,18 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
 
   private static final long DEFAULT_PROFILE_MIN_INTERVAL_MS = 500L;
 
+  /**
+   * Phantom-cycle detection window/threshold/reset-delay. See {@link PhantomCycleDetector}.
+   */
+  private static final long PHANTOM_WINDOW_MS = 60_000L;
+  private static final int PHANTOM_CYCLE_THRESHOLD = 2;
+  private static final long PHANTOM_RESET_DELAY_MS = 2_000L;
+
   private final AtomicInteger transactionId = new AtomicInteger();
   private final Logger logger = LoggerFactory.getLogger(ConnectorThingHandler.class);
+
+  private final PhantomCycleDetector phantomDetector =
+      new PhantomCycleDetector(PHANTOM_WINDOW_MS, PHANTOM_CYCLE_THRESHOLD);
 
   private OcppSender ocppSender;
   private String chargerSerialNumber;
@@ -253,7 +267,55 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
       resetSessionState(null, null);
     }
 
+    trackPhantomCycle(status);
+
     return new StatusNotificationConfirmation();
+  }
+
+  private void trackPhantomCycle(ChargePointStatus status) {
+    if (phantomDetector.record(status, System.currentTimeMillis())) {
+      logger.warn("Connector {} returned to Available {}+ times within {}s without charging —"
+              + " resetting connector state via ChangeAvailability(Inoperative→Operative)",
+          getThing().getUID(), PHANTOM_CYCLE_THRESHOLD, PHANTOM_WINDOW_MS / 1000);
+      resetConnectorState();
+    }
+  }
+
+  private void resetConnectorState() {
+    Integer connector = resolveConnectorId();
+    if (ocppSender == null || chargerSerialNumber == null || connector == null) {
+      return;
+    }
+    ChargerReference reference = new ChargerReference(chargerSerialNumber);
+    ocppSender.send(reference, new ChangeAvailabilityRequest(connector, AvailabilityType.Inoperative))
+        .whenComplete((confirmation, ex) -> {
+          if (ex != null) {
+            logger.warn("ChangeAvailability(Inoperative) for {} failed: {}", getThing().getUID(), ex.getMessage());
+            return;
+          }
+          scheduler.schedule(() -> ocppSender.send(reference,
+              new ChangeAvailabilityRequest(connector, AvailabilityType.Operative))
+              .whenComplete((c, e) -> {
+                if (e != null) {
+                  logger.warn("ChangeAvailability(Operative) for {} failed: {}", getThing().getUID(), e.getMessage());
+                }
+              }), PHANTOM_RESET_DELAY_MS, TimeUnit.MILLISECONDS);
+        });
+  }
+
+  private Integer resolveConnectorId() {
+    Object value = getThing().getConfiguration().get("connectorId");
+    if (value instanceof Number) {
+      return ((Number) value).intValue();
+    }
+    if (value instanceof String) {
+      try {
+        return Integer.parseInt(((String) value).trim());
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    return null;
   }
 
   @Override

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/PhantomCycleDetector.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/PhantomCycleDetector.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2022-2022 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.binding.ocpp.internal.server;
+
+import eu.chargetime.ocpp.model.core.ChargePointStatus;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Detects phantom connector cycles. Some charger firmwares (observed on Wallbox Copper SB)
+ * hallucinate plug-in events: the connector flaps Available → SuspendedEV → Finishing → Available
+ * with no cable, never reaching Charging. A real session always passes through Charging.
+ *
+ * <p>Feed every StatusNotification into {@link #record(ChargePointStatus, long)}; it returns
+ * {@code true} when the connector has returned to Available {@code threshold}+ times within
+ * {@code windowMs} without an intervening Charging state, which is the cue to reset the connector's
+ * state machine (e.g. via ChangeAvailability Inoperative → Operative).
+ */
+public class PhantomCycleDetector {
+
+  private final long windowMs;
+  private final int threshold;
+  private final Deque<Long> availableTimestamps = new ArrayDeque<>();
+  private boolean chargingSinceAvailable;
+
+  public PhantomCycleDetector(long windowMs, int threshold) {
+    this.windowMs = windowMs;
+    this.threshold = threshold;
+  }
+
+  /**
+   * Record a status sample.
+   *
+   * @return {@code true} if this sample completes a phantom-cycle threshold and a reset should fire.
+   *     The internal counter is cleared when this returns {@code true}, so a subsequent reset needs
+   *     a fresh run of cycles.
+   */
+  public synchronized boolean record(ChargePointStatus status, long nowMs) {
+    if (status == ChargePointStatus.Charging) {
+      chargingSinceAvailable = true;
+      return false;
+    }
+    if (status != ChargePointStatus.Available) {
+      return false;
+    }
+    if (chargingSinceAvailable) {
+      // A real session ran since the last Available — not a phantom cycle.
+      chargingSinceAvailable = false;
+      availableTimestamps.clear();
+      return false;
+    }
+    availableTimestamps.addLast(nowMs);
+    while (!availableTimestamps.isEmpty() && nowMs - availableTimestamps.peekFirst() > windowMs) {
+      availableTimestamps.removeFirst();
+    }
+    if (availableTimestamps.size() >= threshold) {
+      availableTimestamps.clear();
+      return true;
+    }
+    return false;
+  }
+
+  public synchronized int pendingCycles() {
+    return availableTimestamps.size();
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/PhantomCycleDetector.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/PhantomCycleDetector.java
@@ -37,6 +37,7 @@ public class PhantomCycleDetector {
   private final int threshold;
   private final Deque<Long> availableTimestamps = new ArrayDeque<>();
   private boolean chargingSinceAvailable;
+  private ChargePointStatus lastStatus;
 
   public PhantomCycleDetector(long windowMs, int threshold) {
     this.windowMs = windowMs;
@@ -51,6 +52,8 @@ public class PhantomCycleDetector {
    *     a fresh run of cycles.
    */
   public synchronized boolean record(ChargePointStatus status, long nowMs) {
+    ChargePointStatus previous = lastStatus;
+    lastStatus = status;
     if (status == ChargePointStatus.Charging) {
       chargingSinceAvailable = true;
       return false;
@@ -62,6 +65,13 @@ public class PhantomCycleDetector {
       // A real session ran since the last Available — not a phantom cycle.
       chargingSinceAvailable = false;
       availableTimestamps.clear();
+      return false;
+    }
+    if (previous == null || previous == ChargePointStatus.Available) {
+      // Only a genuine return counts: the connector must have actually left Available and come
+      // back. A charger re-announcing Available on (re)connect or in response to a TriggerMessage
+      // reports the same state repeatedly — those duplicates are not cycles and must not trip the
+      // detector (otherwise the connect/reconnect status burst fires it at startup).
       return false;
     }
     availableTimestamps.addLast(nowMs);

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/PhantomCycleDetectorTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/PhantomCycleDetectorTest.java
@@ -31,13 +31,27 @@ class PhantomCycleDetectorTest {
   private final PhantomCycleDetector detector = new PhantomCycleDetector(60_000L, 2);
 
   @Test
-  void firesAfterTwoPhantomCyclesInWindow() {
-    // First phantom cycle: Available without ever charging.
-    assertThat(detector.record(Available, 0)).isFalse();
+  void firesAfterTwoGenuineCyclesInWindow() {
+    // A phantom cycle flaps Available -> SuspendedEV -> Finishing -> Available without charging.
+    assertThat(detector.record(Available, 0)).isFalse(); // initial state, not yet a return
     assertThat(detector.record(SuspendedEV, 100)).isFalse();
     assertThat(detector.record(Finishing, 200)).isFalse();
-    // Second return to Available within the window — threshold reached.
-    assertThat(detector.record(Available, 1_000)).isTrue();
+    assertThat(detector.record(Available, 300)).isFalse(); // genuine return #1
+    assertThat(detector.record(SuspendedEV, 400)).isFalse();
+    assertThat(detector.record(Finishing, 500)).isFalse();
+    assertThat(detector.record(Available, 600)).isTrue(); // genuine return #2 -> threshold reached
+  }
+
+  @Test
+  void doesNotFireOnRepeatedAvailableReports() {
+    // A charger re-announcing Available on (re)connect or after a TriggerMessage reports the same
+    // state repeatedly. Those duplicates are NOT cycles and must not trip the detector — this is the
+    // connect/reconnect status burst that otherwise fires it at startup.
+    assertThat(detector.record(Available, 0)).isFalse();
+    assertThat(detector.record(Available, 1_000)).isFalse();
+    assertThat(detector.record(Available, 2_000)).isFalse();
+    assertThat(detector.record(Available, 3_000)).isFalse();
+    assertThat(detector.pendingCycles()).isZero();
   }
 
   @Test
@@ -46,36 +60,47 @@ class PhantomCycleDetectorTest {
     assertThat(detector.record(Preparing, 100)).isFalse();
     assertThat(detector.record(Charging, 200)).isFalse();
     assertThat(detector.record(Finishing, 300)).isFalse();
-    // Return to Available after a real session — counter was cleared, no fire.
+    // Return to Available after a real session — counter cleared, no fire.
     assertThat(detector.record(Available, 400)).isFalse();
     assertThat(detector.pendingCycles()).isZero();
   }
 
   @Test
-  void doesNotFireWhenCyclesAreOutsideWindow() {
-    assertThat(detector.record(Available, 0)).isFalse();
-    // Second Available is 70s later — first timestamp pruned, count stays at 1.
-    assertThat(detector.record(Available, 70_000)).isFalse();
+  void doesNotFireWhenGenuineCyclesAreOutsideWindow() {
+    assertThat(detector.record(Available, 0)).isFalse(); // initial
+    assertThat(detector.record(Preparing, 10)).isFalse();
+    assertThat(detector.record(Available, 100)).isFalse(); // genuine return #1
+    assertThat(detector.record(Preparing, 70_000)).isFalse();
+    // Genuine return #2 is 70s after the first — the first timestamp is pruned, count stays at 1.
+    assertThat(detector.record(Available, 70_100)).isFalse();
     assertThat(detector.pendingCycles()).isEqualTo(1);
   }
 
   @Test
   void clearsCounterAfterFiring() {
     detector.record(Available, 0);
-    assertThat(detector.record(Available, 1_000)).isTrue();
+    detector.record(Preparing, 10);
+    detector.record(Available, 100); // return #1
+    detector.record(Preparing, 110);
+    assertThat(detector.record(Available, 200)).isTrue(); // return #2 -> fire, counter cleared
     // A fresh run of cycles is needed before it fires again.
-    assertThat(detector.record(Available, 2_000)).isFalse();
-    assertThat(detector.record(Available, 3_000)).isTrue();
+    detector.record(Preparing, 210);
+    assertThat(detector.record(Available, 300)).isFalse(); // return #1 of the new run
+    detector.record(Preparing, 310);
+    assertThat(detector.record(Available, 400)).isTrue(); // return #2 -> fire again
   }
 
   @Test
   void chargingMidFlapResetsTheCount() {
     assertThat(detector.record(Available, 0)).isFalse();
-    assertThat(detector.record(Charging, 500)).isFalse();
+    assertThat(detector.record(Preparing, 50)).isFalse();
+    assertThat(detector.record(Available, 100)).isFalse(); // genuine return #1
+    assertThat(detector.record(Charging, 150)).isFalse();
     // Return to Available after a real session clears the pending count (legitimate teardown).
-    assertThat(detector.record(Available, 1_000)).isFalse();
+    assertThat(detector.record(Available, 200)).isFalse();
     assertThat(detector.pendingCycles()).isZero();
-    // A subsequent lone phantom Available is then only count 1 — not enough to fire.
-    assertThat(detector.record(Available, 2_000)).isFalse();
+    // A subsequent lone genuine return is then only count 1 — not enough to fire.
+    assertThat(detector.record(Preparing, 250)).isFalse();
+    assertThat(detector.record(Available, 300)).isFalse();
   }
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/PhantomCycleDetectorTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/PhantomCycleDetectorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2022-2022 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.binding.ocpp.internal.server;
+
+import static eu.chargetime.ocpp.model.core.ChargePointStatus.Available;
+import static eu.chargetime.ocpp.model.core.ChargePointStatus.Charging;
+import static eu.chargetime.ocpp.model.core.ChargePointStatus.Finishing;
+import static eu.chargetime.ocpp.model.core.ChargePointStatus.Preparing;
+import static eu.chargetime.ocpp.model.core.ChargePointStatus.SuspendedEV;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PhantomCycleDetectorTest {
+
+  private final PhantomCycleDetector detector = new PhantomCycleDetector(60_000L, 2);
+
+  @Test
+  void firesAfterTwoPhantomCyclesInWindow() {
+    // First phantom cycle: Available without ever charging.
+    assertThat(detector.record(Available, 0)).isFalse();
+    assertThat(detector.record(SuspendedEV, 100)).isFalse();
+    assertThat(detector.record(Finishing, 200)).isFalse();
+    // Second return to Available within the window — threshold reached.
+    assertThat(detector.record(Available, 1_000)).isTrue();
+  }
+
+  @Test
+  void doesNotFireWhenChargingHappened() {
+    assertThat(detector.record(Available, 0)).isFalse();
+    assertThat(detector.record(Preparing, 100)).isFalse();
+    assertThat(detector.record(Charging, 200)).isFalse();
+    assertThat(detector.record(Finishing, 300)).isFalse();
+    // Return to Available after a real session — counter was cleared, no fire.
+    assertThat(detector.record(Available, 400)).isFalse();
+    assertThat(detector.pendingCycles()).isZero();
+  }
+
+  @Test
+  void doesNotFireWhenCyclesAreOutsideWindow() {
+    assertThat(detector.record(Available, 0)).isFalse();
+    // Second Available is 70s later — first timestamp pruned, count stays at 1.
+    assertThat(detector.record(Available, 70_000)).isFalse();
+    assertThat(detector.pendingCycles()).isEqualTo(1);
+  }
+
+  @Test
+  void clearsCounterAfterFiring() {
+    detector.record(Available, 0);
+    assertThat(detector.record(Available, 1_000)).isTrue();
+    // A fresh run of cycles is needed before it fires again.
+    assertThat(detector.record(Available, 2_000)).isFalse();
+    assertThat(detector.record(Available, 3_000)).isTrue();
+  }
+
+  @Test
+  void chargingMidFlapResetsTheCount() {
+    assertThat(detector.record(Available, 0)).isFalse();
+    assertThat(detector.record(Charging, 500)).isFalse();
+    // Return to Available after a real session clears the pending count (legitimate teardown).
+    assertThat(detector.record(Available, 1_000)).isFalse();
+    assertThat(detector.pendingCycles()).isZero();
+    // A subsequent lone phantom Available is then only count 1 — not enough to fire.
+    assertThat(detector.record(Available, 2_000)).isFalse();
+  }
+}


### PR DESCRIPTION
Some charger firmwares hallucinate plug-in events: the connector flaps Available → SuspendedEV → Finishing → Available with no cable, never reaching Charging, and gets stuck in a false "occupied" state that blocks new sessions. Observed on Wallbox Copper SB (FW 6.7.38). A real session always passes through Charging.

New `PhantomCycleDetector` counts returns to Available without an intervening Charging within a sliding 60s window. When the connector flaps twice without charging, `ConnectorThingHandler` resets its state machine with `ChangeAvailability(Inoperative → Operative)`, 2s apart. Legitimate teardown (a real session ending) clears the counter, so normal use never triggers a reset. Detection is isolated for unit testing; the handler owns the recovery dispatch.
