### PR TITLE
[ocpp] Coalesce rapid SetChargingProfile sends per connector

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ConnectorConfig.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ConnectorConfig.java
@@ -23,4 +23,5 @@ public class ConnectorConfig implements Configuration {
   public static final String DEFAULT_REMOTE_START_TAG = "openhab";
   public Integer connectorId;
   public String remoteStartTag = DEFAULT_REMOTE_START_TAG;
+  public Integer profileMinIntervalMs;
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandler.java
@@ -7,8 +7,10 @@ import eu.chargetime.ocpp.model.core.ChargingRateUnitType;
 import eu.chargetime.ocpp.model.core.ChargingSchedule;
 import eu.chargetime.ocpp.model.core.ChargingSchedulePeriod;
 import eu.chargetime.ocpp.model.smartcharging.SetChargingProfileRequest;
-import org.connectorio.addons.binding.ocpp.internal.OcppSender;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
+import org.connectorio.addons.binding.ocpp.internal.server.SetChargingProfileCoalescer;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.types.Command;
@@ -21,6 +23,9 @@ public class ChargeLimitCommandHandler {
     // Last non-zero limit requested, restored on resume (pause = limit 0).
     private double lastRequestedLimit = -1;
 
+    // One coalescer per handler instance — handlers are created per connector.
+    private SetChargingProfileCoalescer coalescer;
+
     public void handle(Command command, ConnectorCommandContext context) {
         double limit;
         if (command instanceof DecimalType) {
@@ -31,15 +36,21 @@ public class ChargeLimitCommandHandler {
             logger.warn("Unsupported command type for chargeLimit: {}", command.getClass());
             return;
         }
+        if (!canSend(context)) {
+            return;
+        }
         if (limit > 0) {
             lastRequestedLimit = limit;
         }
-        sendChargingProfile(limit, context.getOcppSender(), context.getChargerSerialNumber(), context.getConnectorId());
+        coalescer(context).submit((int) Math.round(limit));
     }
 
     /** Pause charging by applying a 0 A limit (OCPP has no dedicated pause command). */
     public void pause(ConnectorCommandContext context) {
-        sendChargingProfile(0, context.getOcppSender(), context.getChargerSerialNumber(), context.getConnectorId());
+        if (!canSend(context)) {
+            return;
+        }
+        coalescer(context).submit(0);
     }
 
     /** Resume charging by restoring the last non-zero limit. */
@@ -48,19 +59,36 @@ public class ChargeLimitCommandHandler {
             logger.info("No prior charge limit to resume to; awaiting next chargeLimit command.");
             return;
         }
-        sendChargingProfile(lastRequestedLimit, context.getOcppSender(), context.getChargerSerialNumber(), context.getConnectorId());
-    }
-
-    private void sendChargingProfile(double limit, OcppSender ocppSender, String chargerSerialNumber, Integer connectorId) {
-        if (ocppSender == null || chargerSerialNumber == null || connectorId == null) {
-            logger.warn("OcppSender, charger serial or connector id not set. Cannot send charging profile.");
+        if (!canSend(context)) {
             return;
         }
+        coalescer(context).submit((int) Math.round(lastRequestedLimit));
+    }
 
-        ChargerReference chargerRef = new ChargerReference(chargerSerialNumber);
+    private boolean canSend(ConnectorCommandContext context) {
+        if (context.getOcppSender() == null || context.getChargerSerialNumber() == null
+                || context.getConnectorId() == null) {
+            logger.warn("OcppSender, charger serial or connector id not set. Cannot send charging profile.");
+            return false;
+        }
+        return true;
+    }
 
-        // Create charging profile with the specified limit
-        ChargingSchedulePeriod period = new ChargingSchedulePeriod(0, limit);
+    private synchronized SetChargingProfileCoalescer coalescer(ConnectorCommandContext context) {
+        if (coalescer == null) {
+            coalescer = new SetChargingProfileCoalescer(
+                context.getProfileMinIntervalMs(),
+                System::currentTimeMillis,
+                wire -> sendChargingProfile(wire, context),
+                (task, delayMs) -> context.getScheduler().schedule(task, delayMs, TimeUnit.MILLISECONDS));
+        }
+        return coalescer;
+    }
+
+    private CompletionStage<?> sendChargingProfile(int limit, ConnectorCommandContext context) {
+        ChargerReference chargerRef = new ChargerReference(context.getChargerSerialNumber());
+
+        ChargingSchedulePeriod period = new ChargingSchedulePeriod(0, (double) limit);
         ChargingSchedule schedule = new ChargingSchedule(
             ChargingRateUnitType.A,
             new ChargingSchedulePeriod[]{ period }
@@ -73,9 +101,9 @@ public class ChargeLimitCommandHandler {
         profile.setChargingProfileKind(ChargingProfileKindType.Relative);
         profile.setChargingSchedule(schedule);
 
-        SetChargingProfileRequest setProfileRequest = new SetChargingProfileRequest(connectorId, profile);
-        
-        ocppSender.send(chargerRef, setProfileRequest).whenComplete((confirmation, throwable) -> {
+        SetChargingProfileRequest setProfileRequest = new SetChargingProfileRequest(context.getConnectorId(), profile);
+
+        return context.getOcppSender().send(chargerRef, setProfileRequest).whenComplete((confirmation, throwable) -> {
             if (throwable != null) {
                 logger.warn("Failed to send SetChargingProfile with limit {}", limit, throwable);
             } else {

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorCommandContext.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorCommandContext.java
@@ -1,5 +1,6 @@
 package org.connectorio.addons.binding.ocpp.internal.handler;
 
+import java.util.concurrent.ScheduledExecutorService;
 import org.connectorio.addons.binding.ocpp.internal.OcppSender;
 
 public interface ConnectorCommandContext {
@@ -8,4 +9,6 @@ public interface ConnectorCommandContext {
     String getRemoteStartTag();
     Integer getCurrentTransactionId();
     Integer getConnectorId();
+    ScheduledExecutorService getScheduler();
+    long getProfileMinIntervalMs();
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -56,6 +56,9 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
   void setTransactionId(int value) {
     this.transactionId.set(value);
   }
+
+  private static final long DEFAULT_PROFILE_MIN_INTERVAL_MS = 500L;
+
   private final AtomicInteger transactionId = new AtomicInteger();
   private final Logger logger = LoggerFactory.getLogger(ConnectorThingHandler.class);
 
@@ -106,6 +109,20 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
   @Override
   public Integer getConnectorId() {
     return connectorId;
+  }
+
+  @Override
+  public java.util.concurrent.ScheduledExecutorService getScheduler() {
+    return scheduler;
+  }
+
+  @Override
+  public long getProfileMinIntervalMs() {
+    return getThingConfig()
+        .map(config -> config.profileMinIntervalMs)
+        .filter(value -> value != null && value >= 0)
+        .map(Integer::longValue)
+        .orElse(DEFAULT_PROFILE_MIN_INTERVAL_MS);
   }
 
   @Override

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/SetChargingProfileCoalescer.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/SetChargingProfileCoalescer.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2022-2022 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.binding.ocpp.internal.server;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.LongSupplier;
+
+/**
+ * Coalesces rapid charge-limit changes into at most one in-flight SetChargingProfile CALL plus one
+ * pending value, so a fast caller (a solar/EMS loop adjusting amperage many times a second) cannot
+ * flood the charger's OCPP queue.
+ *
+ * <p>While a SetChargingProfile is in flight, further {@link #submit(int)} calls only overwrite the
+ * pending value — they do not enqueue more CALLs. When the in-flight CALL settles, if the pending
+ * value still differs from what was just sent, exactly one follow-up CALL is scheduled, no sooner
+ * than {@code minIntervalMs} after the previous send. This keeps Phoenix Contact CHARX SEC-3xxx
+ * (whose OCPP queue is slow) from backing up under load while still converging on the latest
+ * desired current.
+ *
+ * <p>The class is transport-agnostic: {@code sender} performs the actual CALL and returns its
+ * future; {@code delayedExecutor} schedules the drain; {@code clock} supplies the current time
+ * (injected for testability).
+ */
+public class SetChargingProfileCoalescer {
+
+  @FunctionalInterface
+  public interface Sender {
+    CompletionStage<?> send(int wireValue);
+  }
+
+  @FunctionalInterface
+  public interface DelayedExecutor {
+    void schedule(Runnable task, long delayMs);
+  }
+
+  private final long minIntervalMs;
+  private final LongSupplier clock;
+  private final Sender sender;
+  private final DelayedExecutor delayedExecutor;
+
+  private Integer inFlight;
+  private Integer pending;
+  private long lastSentAtMs;
+  private boolean drainScheduled;
+
+  public SetChargingProfileCoalescer(long minIntervalMs, LongSupplier clock, Sender sender,
+      DelayedExecutor delayedExecutor) {
+    this.minIntervalMs = minIntervalMs;
+    this.clock = clock;
+    this.sender = sender;
+    this.delayedExecutor = delayedExecutor;
+  }
+
+  /** Request that {@code wireValue} reach the charger, coalescing with any in-flight or pending send. */
+  public synchronized void submit(int wireValue) {
+    if (inFlight != null) {
+      pending = wireValue;
+      return;
+    }
+    sendNow(wireValue);
+  }
+
+  private void sendNow(int wireValue) {
+    inFlight = wireValue;
+    lastSentAtMs = clock.getAsLong();
+    sender.send(wireValue).whenComplete((result, error) -> settled());
+  }
+
+  private synchronized void settled() {
+    Integer wasInFlight = inFlight;
+    inFlight = null;
+    if (pending == null || pending.equals(wasInFlight)) {
+      pending = null;
+      return;
+    }
+    if (drainScheduled) {
+      return;
+    }
+    long elapsed = clock.getAsLong() - lastSentAtMs;
+    long delay = Math.max(0L, minIntervalMs - elapsed);
+    drainScheduled = true;
+    delayedExecutor.schedule(this::drain, delay);
+  }
+
+  private synchronized void drain() {
+    drainScheduled = false;
+    if (pending == null) {
+      return;
+    }
+    int next = pending;
+    pending = null;
+    sendNow(next);
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -329,6 +329,18 @@
         <description>Tag to use for remote start transactions. Defaults to "openhab" if not specified.</description>
         <default>openhab</default>
       </parameter>
+      <parameter name="profileMinIntervalMs" type="integer" required="false" min="0">
+        <label>SetChargingProfile Min Interval (ms)</label>
+        <description>
+          Minimum gap between consecutive SetChargingProfile CALLs to this connector. Rapid
+          charge-limit changes are coalesced — at most one CALL in flight plus the latest pending
+          value — so a fast caller cannot flood the charger's OCPP queue. Higher values help slow
+          chargers such as Phoenix Contact CHARX SEC-3xxx.
+        </description>
+        <default>500</default>
+        <unitLabel>ms</unitLabel>
+        <advanced>true</advanced>
+      </parameter>
     </config-description>
 
   </thing-type>

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandlerTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandlerTest.java
@@ -40,9 +40,16 @@ class ChargeLimitCommandHandlerTest {
     handler = new ChargeLimitCommandHandler();
   }
 
+  private void stubCoalescer() {
+    // getProfileMinIntervalMs() is read when the coalescer is constructed; getScheduler() is only
+    // touched if a drain is scheduled, which a single idle submit never triggers.
+    when(context.getProfileMinIntervalMs()).thenReturn(0L);
+  }
+
   @Test
   void shouldSendSetChargingProfileForDecimalType() {
     // given
+    stubCoalescer();
     when(context.getOcppSender()).thenReturn(sender);
     when(context.getChargerSerialNumber()).thenReturn("charger-serial");
     when(context.getConnectorId()).thenReturn(2);
@@ -63,6 +70,7 @@ class ChargeLimitCommandHandlerTest {
   @Test
   void shouldSendSetChargingProfileForQuantityType() {
     // given
+    stubCoalescer();
     when(context.getOcppSender()).thenReturn(sender);
     when(context.getChargerSerialNumber()).thenReturn("charger-serial");
     when(context.getConnectorId()).thenReturn(1);

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/SetChargingProfileCoalescerTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/SetChargingProfileCoalescerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2022-2022 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.binding.ocpp.internal.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+class SetChargingProfileCoalescerTest {
+
+  /** Records each wireValue sent and hands back a future the test completes by hand. */
+  private static class RecordingSender implements SetChargingProfileCoalescer.Sender {
+    final List<Integer> sent = new ArrayList<>();
+    final List<CompletableFuture<Object>> futures = new ArrayList<>();
+
+    @Override
+    public CompletableFuture<Object> send(int wireValue) {
+      sent.add(wireValue);
+      CompletableFuture<Object> future = new CompletableFuture<>();
+      futures.add(future);
+      return future;
+    }
+
+    void complete(int index) {
+      futures.get(index).complete(null);
+    }
+  }
+
+  /** Runs scheduled drains immediately so timing is deterministic. */
+  private static final SetChargingProfileCoalescer.DelayedExecutor IMMEDIATE =
+      (task, delayMs) -> task.run();
+
+  @Test
+  void sendsImmediatelyWhenIdle() {
+    RecordingSender sender = new RecordingSender();
+    SetChargingProfileCoalescer coalescer =
+        new SetChargingProfileCoalescer(500, () -> 0L, sender, IMMEDIATE);
+
+    coalescer.submit(10);
+
+    assertThat(sender.sent).containsExactly(10);
+  }
+
+  @Test
+  void coalescesWhileInFlightAndSendsOnlyLatest() {
+    RecordingSender sender = new RecordingSender();
+    long[] now = {0L};
+    SetChargingProfileCoalescer coalescer =
+        new SetChargingProfileCoalescer(0, () -> now[0], sender, IMMEDIATE);
+
+    coalescer.submit(10);     // sent immediately, in flight
+    coalescer.submit(12);     // coalesced into pending
+    coalescer.submit(14);     // overwrites pending — 12 never reaches the wire
+    assertThat(sender.sent).containsExactly(10);
+
+    sender.complete(0);       // in-flight settles → drains pending (14)
+    assertThat(sender.sent).containsExactly(10, 14);
+  }
+
+  @Test
+  void doesNotResendWhenPendingEqualsInFlight() {
+    RecordingSender sender = new RecordingSender();
+    SetChargingProfileCoalescer coalescer =
+        new SetChargingProfileCoalescer(0, () -> 0L, sender, IMMEDIATE);
+
+    coalescer.submit(10);
+    coalescer.submit(10);     // same value while in flight — nothing new to send
+    sender.complete(0);
+
+    assertThat(sender.sent).containsExactly(10);
+  }
+
+  @Test
+  void sequentialIdleSendsEachGoOut() {
+    RecordingSender sender = new RecordingSender();
+    SetChargingProfileCoalescer coalescer =
+        new SetChargingProfileCoalescer(0, () -> 0L, sender, IMMEDIATE);
+
+    coalescer.submit(10);
+    sender.complete(0);       // settles, nothing pending
+    coalescer.submit(16);     // idle again → sends
+    sender.complete(1);
+
+    assertThat(sender.sent).containsExactly(10, 16);
+  }
+
+  @Test
+  void respectsMinIntervalBeforeDraining() {
+    RecordingSender sender = new RecordingSender();
+    long[] now = {0L};
+    List<Long> scheduledDelays = new ArrayList<>();
+    SetChargingProfileCoalescer.DelayedExecutor capturing = (task, delayMs) -> {
+      scheduledDelays.add(delayMs);
+      task.run();
+    };
+    SetChargingProfileCoalescer coalescer =
+        new SetChargingProfileCoalescer(500, () -> now[0], sender, capturing);
+
+    coalescer.submit(10);     // sent at t=0
+    coalescer.submit(14);     // pending
+    now[0] = 200L;            // 200ms elapsed when it settles
+    sender.complete(0);
+
+    // Drain scheduled with the remaining 300ms of the 500ms minimum interval.
+    assertThat(scheduledDelays).containsExactly(300L);
+    assertThat(sender.sent).containsExactly(10, 14);
+  }
+}


### PR DESCRIPTION
A caller that adjusts the charge limit many times a second (a solar/EMS loop tracking available power) can flood a charger's OCPP queue with `SetChargingProfile` CALLs. Phoenix Contact CHARX SEC-3xxx then spends minutes working through the backlog, occasionally returning `InternalError`.

New `SetChargingProfileCoalescer` keeps at most one CALL in flight plus one pending value. While a send is outstanding, further submits only overwrite the pending value; when the in-flight CALL settles, a single follow-up is scheduled no sooner than `profileMinIntervalMs` (per-connector config, default 500ms) after the previous send. The latest desired current always reaches the charger; intermediate values are dropped. Coalescing logic is isolated for unit testing with an injected clock, sender and executor.

Verified against CHARX SEC-3xxx (FW 1.9.0): firing 50 limit changes in a few seconds now produces two wire CALLs (first + latest) instead of 50, and the connector no longer backs up.
