### PR TITLE
[ocpp] Recover connectors stuck in Finishing or Faulted

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -1,6 +1,9 @@
 package org.connectorio.addons.binding.ocpp.internal.handler;
 
+import eu.chargetime.ocpp.model.Request;
 import eu.chargetime.ocpp.model.core.AuthorizationStatus;
+import eu.chargetime.ocpp.model.core.AvailabilityType;
+import eu.chargetime.ocpp.model.core.ChangeAvailabilityRequest;
 import eu.chargetime.ocpp.model.core.ChargePointStatus;
 import eu.chargetime.ocpp.model.core.IdTagInfo;
 import eu.chargetime.ocpp.model.core.MeterValue;
@@ -17,8 +20,12 @@ import eu.chargetime.ocpp.model.core.StopTransactionConfirmation;
 import eu.chargetime.ocpp.model.core.StopTransactionRequest;
 import eu.chargetime.ocpp.model.core.UnlockConnectorRequest;
 import eu.chargetime.ocpp.model.core.ValueFormat;
+import eu.chargetime.ocpp.model.remotetrigger.TriggerMessageRequest;
+import eu.chargetime.ocpp.model.remotetrigger.TriggerMessageRequestType;
 import java.time.ZonedDateTime;
 import java.util.Optional;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.measure.Quantity;
 import org.connectorio.addons.binding.handler.GenericThingHandlerBase;
@@ -59,8 +66,15 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
 
   private static final long DEFAULT_PROFILE_MIN_INTERVAL_MS = 500L;
 
+  private static final long WATCHDOG_TICK_SECONDS = 5L;
+  private static final long AVAILABILITY_RESTORE_DELAY_MS = 2_000L;
+
   private final AtomicInteger transactionId = new AtomicInteger();
   private final Logger logger = LoggerFactory.getLogger(ConnectorThingHandler.class);
+
+  private final org.connectorio.addons.binding.ocpp.internal.server.StuckStateWatchdog watchdog =
+      new org.connectorio.addons.binding.ocpp.internal.server.StuckStateWatchdog();
+  private ScheduledFuture<?> watchdogFuture;
 
   private OcppSender ocppSender;
   private String chargerSerialNumber;
@@ -137,7 +151,18 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
     } else {
       remoteStartTag = ConnectorConfig.DEFAULT_REMOTE_START_TAG;
     }
+    watchdogFuture = scheduler.scheduleWithFixedDelay(this::runWatchdog,
+        WATCHDOG_TICK_SECONDS, WATCHDOG_TICK_SECONDS, TimeUnit.SECONDS);
     updateStatus(ThingStatus.ONLINE);
+  }
+
+  @Override
+  public void dispose() {
+    if (watchdogFuture != null) {
+      watchdogFuture.cancel(true);
+      watchdogFuture = null;
+    }
+    super.dispose();
   }
 
   @Override
@@ -253,7 +278,79 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
       resetSessionState(null, null);
     }
 
+    watchdog.onStatus(status, System.currentTimeMillis());
+
     return new StatusNotificationConfirmation();
+  }
+
+  private void runWatchdog() {
+    org.connectorio.addons.binding.ocpp.internal.server.StuckStateWatchdog.Action action =
+        watchdog.evaluate(System.currentTimeMillis());
+    if (action == org.connectorio.addons.binding.ocpp.internal.server.StuckStateWatchdog.Action.NONE) {
+      return;
+    }
+    Integer connector = resolveConnectorId();
+    if (ocppSender == null || chargerSerialNumber == null || connector == null) {
+      return;
+    }
+    ChargerReference reference = new ChargerReference(chargerSerialNumber);
+    switch (action) {
+      case TRIGGER_STATUS:
+        logger.info("Connector {} stuck — nudging with TriggerMessage(StatusNotification)", getThing().getUID());
+        TriggerMessageRequest trigger = new TriggerMessageRequest(TriggerMessageRequestType.StatusNotification);
+        trigger.setConnectorId(connector);
+        sendRecovery(reference, trigger, "TriggerMessage(StatusNotification)");
+        break;
+      case CHANGE_AVAILABILITY:
+        logger.warn("Connector {} stuck — cycling ChangeAvailability(Inoperative->Operative)", getThing().getUID());
+        cycleAvailability(reference, connector);
+        break;
+      case UNLOCK:
+        logger.error("Connector {} still stuck — sending UnlockConnector; physical intervention may be required",
+            getThing().getUID());
+        sendRecovery(reference, new UnlockConnectorRequest(connector), "UnlockConnector");
+        break;
+      default:
+        break;
+    }
+  }
+
+  private void cycleAvailability(ChargerReference reference, Integer connector) {
+    ocppSender.send(reference, new ChangeAvailabilityRequest(connector, AvailabilityType.Inoperative))
+        .whenComplete((confirmation, ex) -> {
+          if (ex != null) {
+            logger.warn("ChangeAvailability(Inoperative) for {} failed: {}", getThing().getUID(), ex.getMessage());
+            return;
+          }
+          scheduler.schedule(() -> sendRecovery(reference,
+              new ChangeAvailabilityRequest(connector, AvailabilityType.Operative),
+              "ChangeAvailability(Operative)"), AVAILABILITY_RESTORE_DELAY_MS, TimeUnit.MILLISECONDS);
+        });
+  }
+
+  private void sendRecovery(ChargerReference reference, Request request, String label) {
+    ocppSender.send(reference, request).whenComplete((confirmation, ex) -> {
+      if (ex != null) {
+        logger.warn("{} for {} failed: {}", label, getThing().getUID(), ex.getMessage());
+      } else {
+        logger.debug("{} for {}: {}", label, getThing().getUID(), confirmation);
+      }
+    });
+  }
+
+  private Integer resolveConnectorId() {
+    Object value = getThing().getConfiguration().get("connectorId");
+    if (value instanceof Number) {
+      return ((Number) value).intValue();
+    }
+    if (value instanceof String) {
+      try {
+        return Integer.parseInt(((String) value).trim());
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    return null;
   }
 
   @Override

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/StuckStateWatchdog.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/StuckStateWatchdog.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2022-2022 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.binding.ocpp.internal.server;
+
+import eu.chargetime.ocpp.model.core.ChargePointStatus;
+
+/**
+ * Decides when and how to recover a connector that is stuck. Some chargers hang in
+ * {@link ChargePointStatus#Finishing} (a transaction that never fully tears down) or
+ * {@link ChargePointStatus#Faulted}, blocking new sessions until someone physically intervenes.
+ * Phoenix Contact CHARX SEC-3xxx is prone to the Finishing hang.
+ *
+ * <p>Feed every StatusNotification into {@link #onStatus(ChargePointStatus, long)} and call
+ * {@link #evaluate(long)} on a timer. While the connector sits in a stuck state, {@code evaluate}
+ * escalates once per tier:
+ *
+ * <ol>
+ *   <li>{@value #DEFAULT_NUDGE_MS} ms → {@link Action#TRIGGER_STATUS} (a cheap state refresh);</li>
+ *   <li>{@value #DEFAULT_AVAILABILITY_MS} ms → {@link Action#CHANGE_AVAILABILITY} (force a firmware
+ *       state-machine reset);</li>
+ *   <li>{@value #DEFAULT_UNLOCK_MS} ms → {@link Action#UNLOCK} (terminate a phantom transaction).</li>
+ * </ol>
+ *
+ * <p>A <em>legitimate teardown</em> — a {@code Finishing} that follows a real Charging session
+ * within {@value #DEFAULT_TEARDOWN_GRACE_MS} ms — is treated gently: the {@code ChangeAvailability}
+ * cycle is skipped (it would break the charger's natural wind-down) and the connector is given until
+ * {@value #DEFAULT_TEARDOWN_UNLOCK_MS} ms before any unlock. Normal teardowns (Wallbox Pulsar Plus
+ * can take 30–90 s) therefore never trigger an aggressive reset.
+ */
+public class StuckStateWatchdog {
+
+  public enum Action {
+    NONE,
+    TRIGGER_STATUS,
+    CHANGE_AVAILABILITY,
+    UNLOCK
+  }
+
+  public static final long DEFAULT_NUDGE_MS = 20_000L;
+  public static final long DEFAULT_AVAILABILITY_MS = 40_000L;
+  public static final long DEFAULT_UNLOCK_MS = 60_000L;
+  public static final long DEFAULT_TEARDOWN_GRACE_MS = 300_000L;
+  public static final long DEFAULT_TEARDOWN_UNLOCK_MS = 180_000L;
+
+  private final long nudgeMs;
+  private final long availabilityMs;
+  private final long unlockMs;
+  private final long teardownGraceMs;
+  private final long teardownUnlockMs;
+
+  private ChargePointStatus currentStatus;
+  private long stateEnteredMs;
+  private long lastChargingMs = -1L;
+  private int firedTier;
+
+  public StuckStateWatchdog() {
+    this(DEFAULT_NUDGE_MS, DEFAULT_AVAILABILITY_MS, DEFAULT_UNLOCK_MS,
+        DEFAULT_TEARDOWN_GRACE_MS, DEFAULT_TEARDOWN_UNLOCK_MS);
+  }
+
+  public StuckStateWatchdog(long nudgeMs, long availabilityMs, long unlockMs,
+      long teardownGraceMs, long teardownUnlockMs) {
+    this.nudgeMs = nudgeMs;
+    this.availabilityMs = availabilityMs;
+    this.unlockMs = unlockMs;
+    this.teardownGraceMs = teardownGraceMs;
+    this.teardownUnlockMs = teardownUnlockMs;
+  }
+
+  /** Record a status sample. Resets the escalation ladder whenever the status actually changes. */
+  public synchronized void onStatus(ChargePointStatus status, long nowMs) {
+    if (status == ChargePointStatus.Charging) {
+      lastChargingMs = nowMs;
+    }
+    if (status != currentStatus) {
+      currentStatus = status;
+      stateEnteredMs = nowMs;
+      firedTier = 0;
+    }
+  }
+
+  /** @return the next recovery action to perform, or {@link Action#NONE} if nothing is due yet. */
+  public synchronized Action evaluate(long nowMs) {
+    if (currentStatus == null || !isStuckCandidate(currentStatus)) {
+      firedTier = 0;
+      return Action.NONE;
+    }
+    long inState = nowMs - stateEnteredMs;
+    int target = 0;
+    if (isLegitimateTeardown(nowMs)) {
+      // Gentle path: nudge, then a much-delayed unlock. Never ChangeAvailability mid-teardown.
+      if (inState >= nudgeMs) {
+        target = 1;
+      }
+      if (inState >= teardownUnlockMs) {
+        target = 3;
+      }
+    } else {
+      if (inState >= nudgeMs) {
+        target = 1;
+      }
+      if (inState >= availabilityMs) {
+        target = 2;
+      }
+      if (inState >= unlockMs) {
+        target = 3;
+      }
+    }
+    if (target > firedTier) {
+      firedTier = target;
+      return actionForTier(target);
+    }
+    return Action.NONE;
+  }
+
+  private boolean isLegitimateTeardown(long nowMs) {
+    return currentStatus == ChargePointStatus.Finishing
+        && lastChargingMs >= 0
+        && (nowMs - lastChargingMs) < teardownGraceMs;
+  }
+
+  private static boolean isStuckCandidate(ChargePointStatus status) {
+    return status == ChargePointStatus.Finishing || status == ChargePointStatus.Faulted;
+  }
+
+  private static Action actionForTier(int tier) {
+    switch (tier) {
+      case 1:
+        return Action.TRIGGER_STATUS;
+      case 2:
+        return Action.CHANGE_AVAILABILITY;
+      case 3:
+        return Action.UNLOCK;
+      default:
+        return Action.NONE;
+    }
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/StuckStateWatchdogTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/StuckStateWatchdogTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2022-2022 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.connectorio.addons.binding.ocpp.internal.server;
+
+import static eu.chargetime.ocpp.model.core.ChargePointStatus.Available;
+import static eu.chargetime.ocpp.model.core.ChargePointStatus.Charging;
+import static eu.chargetime.ocpp.model.core.ChargePointStatus.Faulted;
+import static eu.chargetime.ocpp.model.core.ChargePointStatus.Finishing;
+import static eu.chargetime.ocpp.model.core.ChargePointStatus.SuspendedEVSE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.connectorio.addons.binding.ocpp.internal.server.StuckStateWatchdog.Action.CHANGE_AVAILABILITY;
+import static org.connectorio.addons.binding.ocpp.internal.server.StuckStateWatchdog.Action.NONE;
+import static org.connectorio.addons.binding.ocpp.internal.server.StuckStateWatchdog.Action.TRIGGER_STATUS;
+import static org.connectorio.addons.binding.ocpp.internal.server.StuckStateWatchdog.Action.UNLOCK;
+
+import org.junit.jupiter.api.Test;
+
+class StuckStateWatchdogTest {
+
+  // nudge=20s, availability=40s, unlock=60s, teardownGrace=300s, teardownUnlock=180s (defaults)
+  private final StuckStateWatchdog watchdog = new StuckStateWatchdog();
+
+  @Test
+  void healthyStatesNeverEscalate() {
+    watchdog.onStatus(Available, 0);
+    assertThat(watchdog.evaluate(100_000)).isEqualTo(NONE);
+    watchdog.onStatus(Charging, 100_000);
+    assertThat(watchdog.evaluate(200_000)).isEqualTo(NONE);
+  }
+
+  @Test
+  void faultedEscalatesThroughAllThreeTiers() {
+    watchdog.onStatus(Faulted, 0);
+    assertThat(watchdog.evaluate(10_000)).isEqualTo(NONE);            // <20s
+    assertThat(watchdog.evaluate(20_000)).isEqualTo(TRIGGER_STATUS);  // 20s
+    assertThat(watchdog.evaluate(30_000)).isEqualTo(NONE);            // already nudged
+    assertThat(watchdog.evaluate(40_000)).isEqualTo(CHANGE_AVAILABILITY); // 40s
+    assertThat(watchdog.evaluate(60_000)).isEqualTo(UNLOCK);          // 60s
+    assertThat(watchdog.evaluate(80_000)).isEqualTo(NONE);            // nothing left
+  }
+
+  @Test
+  void legitimateTeardownSkipsAvailabilityAndDefersUnlock() {
+    // A real session: Charging then Finishing 1s later.
+    watchdog.onStatus(Charging, 0);
+    watchdog.onStatus(Finishing, 1_000);
+
+    // Nudge still fires at 20s into Finishing.
+    assertThat(watchdog.evaluate(21_000)).isEqualTo(TRIGGER_STATUS);
+    // ChangeAvailability is skipped during teardown — 40s in, nothing.
+    assertThat(watchdog.evaluate(41_000)).isEqualTo(NONE);
+    // Still nothing at the normal 60s unlock point.
+    assertThat(watchdog.evaluate(61_000)).isEqualTo(NONE);
+    // Unlock only after the extended teardown window (180s into Finishing → t≈181s).
+    assertThat(watchdog.evaluate(181_000)).isEqualTo(UNLOCK);
+  }
+
+  @Test
+  void phantomFinishingWithoutPriorChargingEscalatesNormally() {
+    // Finishing with no recent Charging is not a legitimate teardown.
+    watchdog.onStatus(Finishing, 0);
+    assertThat(watchdog.evaluate(20_000)).isEqualTo(TRIGGER_STATUS);
+    assertThat(watchdog.evaluate(40_000)).isEqualTo(CHANGE_AVAILABILITY);
+    assertThat(watchdog.evaluate(60_000)).isEqualTo(UNLOCK);
+  }
+
+  @Test
+  void chargingOlderThanGraceIsNotTeardown() {
+    watchdog.onStatus(Charging, 0);
+    // Finishing enters far later — last charging is now older than the 300s grace.
+    watchdog.onStatus(Finishing, 400_000);
+    assertThat(watchdog.evaluate(440_000)).isEqualTo(CHANGE_AVAILABILITY); // 40s in, treated as stuck
+  }
+
+  @Test
+  void statusChangeResetsTheLadder() {
+    watchdog.onStatus(Faulted, 0);
+    assertThat(watchdog.evaluate(20_000)).isEqualTo(TRIGGER_STATUS);
+    // Charger recovers to Available, then faults again — ladder restarts.
+    watchdog.onStatus(Available, 25_000);
+    assertThat(watchdog.evaluate(30_000)).isEqualTo(NONE);
+    watchdog.onStatus(Faulted, 35_000);
+    assertThat(watchdog.evaluate(50_000)).isEqualTo(NONE);            // only 15s into the new Faulted
+    assertThat(watchdog.evaluate(55_000)).isEqualTo(TRIGGER_STATUS);  // 20s into the new Faulted
+  }
+
+  @Test
+  void suspendedEvseIsNotTreatedAsStuck() {
+    // SuspendedEVSE is typically a deliberate pause (chargeLimit=0) — never auto-recovered.
+    watchdog.onStatus(SuspendedEVSE, 0);
+    assertThat(watchdog.evaluate(120_000)).isEqualTo(NONE);
+  }
+}


### PR DESCRIPTION
A connector can hang in `Finishing` (a transaction that never tears down) or `Faulted`, blocking every new session until someone physically unplugs the cable. Phoenix Contact CHARX SEC-3xxx is prone to the Finishing hang.

A per-connector watchdog ticks every 5s and escalates while a connector stays stuck: 20s → `TriggerMessage(StatusNotification)`, 40s → `ChangeAvailability(Inoperative→Operative)`, 60s → `UnlockConnector` with a loud error. A *legitimate teardown* — Finishing within 5 min of a real Charging session — is handled gently: the ChangeAvailability cycle is skipped (it would break the charger's natural wind-down) and the unlock deferred to 180s, so a normal Wallbox Pulsar Plus teardown (30-90s) never triggers an aggressive reset. `SuspendedEVSE` is left alone because it is usually a deliberate pause. Decision logic is isolated for unit testing; the handler owns the timer and recovery CALLs.

Stacks on #141 (uses the RemoteTrigger profile it registers).
