### PR TITLE
[ocpp] Add pause channel for pause/resume without ending the transaction

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/OcppBindingConstants.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/OcppBindingConstants.java
@@ -52,6 +52,7 @@ public interface OcppBindingConstants extends BaseBindingConstants {
   ChannelRef CHARGING = new ChannelRef("charging");
   ChannelRef RESET = new ChannelRef("reset");
   ChannelRef LOCK = new ChannelRef("lock");
+  ChannelRef PAUSE = new ChannelRef("pause");
   ChannelRef ENERGY_ACTIVE_EXPORT = new ChannelRef("energyActiveExport");
   ChannelRef ENERGY_ACTIVE_IMPORT = new ChannelRef("energyActiveImport");
   ChannelRef ENERGY_REACTIVE_EXPORT = new ChannelRef("energyReactiveExport");

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandler.java
@@ -18,6 +18,9 @@ import org.slf4j.LoggerFactory;
 public class ChargeLimitCommandHandler {
     private final Logger logger = LoggerFactory.getLogger(ChargeLimitCommandHandler.class);
 
+    // Last non-zero limit requested, restored on resume (pause = limit 0).
+    private double lastRequestedLimit = -1;
+
     public void handle(Command command, ConnectorCommandContext context) {
         double limit;
         if (command instanceof DecimalType) {
@@ -28,7 +31,24 @@ public class ChargeLimitCommandHandler {
             logger.warn("Unsupported command type for chargeLimit: {}", command.getClass());
             return;
         }
+        if (limit > 0) {
+            lastRequestedLimit = limit;
+        }
         sendChargingProfile(limit, context.getOcppSender(), context.getChargerSerialNumber(), context.getConnectorId());
+    }
+
+    /** Pause charging by applying a 0 A limit (OCPP has no dedicated pause command). */
+    public void pause(ConnectorCommandContext context) {
+        sendChargingProfile(0, context.getOcppSender(), context.getChargerSerialNumber(), context.getConnectorId());
+    }
+
+    /** Resume charging by restoring the last non-zero limit. */
+    public void resume(ConnectorCommandContext context) {
+        if (lastRequestedLimit <= 0) {
+            logger.info("No prior charge limit to resume to; awaiting next chargeLimit command.");
+            return;
+        }
+        sendChargingProfile(lastRequestedLimit, context.getOcppSender(), context.getChargerSerialNumber(), context.getConnectorId());
     }
 
     private void sendChargingProfile(double limit, OcppSender ocppSender, String chargerSerialNumber, Integer connectorId) {

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -138,6 +138,14 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
       if (command == OnOffType.ON) {
         sendUnlock();
       }
+    } else if (OcppBindingConstants.PAUSE.getAsString().equals(channelId)) {
+      if (command instanceof OnOffType) {
+        if (command == OnOffType.ON) {
+          chargeLimitHandler.pause(this);
+        } else {
+          chargeLimitHandler.resume(this);
+        }
+      }
     }
   }
 

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -166,6 +166,10 @@
         <label>Unlock Connector</label>
         <description>Momentary. Send ON to issue UnlockConnector for this connector (releases the cable latch / terminates a stuck transaction); the channel returns to OFF once the request settles.</description>
       </channel>
+      <channel id="pause" typeId="switch">
+        <label>Pause</label>
+        <description>Pause/resume charging without ending the transaction. Send ON to apply a 0 A limit (SetChargingProfile), OFF to restore the last non-zero limit. OCPP 1.6 has no dedicated pause command.</description>
+      </channel>
       <channel id="timestampStart" typeId="dateTime">
         <label>Start timestamp</label>
         <description>Start timestamp of most recent transaction.</description>


### PR DESCRIPTION
OCPP 1.6 has no dedicated pause command — the conventional way to pause a charging EV without ending the transaction is to apply a 0 A limit via `SetChargingProfile`, then restore the previous limit to resume. Today a ConnectorIO user has to script that against the `chargeLimit` channel.

New `pause` Switch channel on the connector: ON applies a 0 A `SetChargingProfile`, OFF restores the last non-zero limit the handler last saw (tracked in `ChargeLimitCommandHandler` so resume returns to whatever the user/EMS last requested).

Verified against Wallbox Copper SB / Pulsar Plus (FW 6.7.38): pause → SuspendedEVSE, resume → Charging at the prior current.
