### PR TITLE
[ocpp] Add cableConnected channel derived from connector status

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/OcppBindingConstants.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/OcppBindingConstants.java
@@ -53,6 +53,7 @@ public interface OcppBindingConstants extends BaseBindingConstants {
   ChannelRef RESET = new ChannelRef("reset");
   ChannelRef LOCK = new ChannelRef("lock");
   ChannelRef PAUSE = new ChannelRef("pause");
+  ChannelRef CABLE_CONNECTED = new ChannelRef("cableConnected");
   ChannelRef ENERGY_ACTIVE_EXPORT = new ChannelRef("energyActiveExport");
   ChannelRef ENERGY_ACTIVE_IMPORT = new ChannelRef("energyActiveImport");
   ChannelRef ENERGY_REACTIVE_EXPORT = new ChannelRef("energyReactiveExport");

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -229,6 +229,10 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
     StringType val = new StringType(status.name());
     getCallback().stateUpdated(new ChannelUID(getThing().getUID(), "chargePointStatus"), val);
 
+    getCallback().stateUpdated(
+        new ChannelUID(getThing().getUID(), OcppBindingConstants.CABLE_CONNECTED.getAsString()),
+        OnOffType.from(isCableConnected(status)));
+
     if (status == ChargePointStatus.Available
         || status == ChargePointStatus.Finishing
         || status == ChargePointStatus.SuspendedEV
@@ -237,6 +241,24 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
     }
 
     return new StatusNotificationConfirmation();
+  }
+
+  /**
+   * Derive cable presence from the OCPP connector status. A cable is considered connected from the
+   * moment the EV is plugged in (Preparing) through the whole session up to teardown (Finishing);
+   * Available/Unavailable/Faulted/Reserved mean nothing is plugged in.
+   */
+  private static boolean isCableConnected(ChargePointStatus status) {
+    switch (status) {
+      case Preparing:
+      case Charging:
+      case SuspendedEV:
+      case SuspendedEVSE:
+      case Finishing:
+        return true;
+      default:
+        return false;
+    }
   }
 
   @Override

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -43,6 +43,7 @@ import org.openhab.core.thing.UID;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.slf4j.Logger;
@@ -229,9 +230,11 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
     StringType val = new StringType(status.name());
     getCallback().stateUpdated(new ChannelUID(getThing().getUID(), "chargePointStatus"), val);
 
+    // Contact, not Switch — this channel is read-only. CLOSED mirrors the physical pilot circuit:
+    // plugging in the cable closes it.
     getCallback().stateUpdated(
         new ChannelUID(getThing().getUID(), OcppBindingConstants.CABLE_CONNECTED.getAsString()),
-        OnOffType.from(isCableConnected(status)));
+        isCableConnected(status) ? OpenClosedType.CLOSED : OpenClosedType.OPEN);
 
     if (status == ChargePointStatus.Available
         || status == ChargePointStatus.Finishing

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/channels.xml
@@ -50,6 +50,13 @@
     <description>On/off control channel.</description>
   </channel-type>
 
+  <channel-type id="contact">
+    <item-type>Contact</item-type>
+    <label>Contact</label>
+    <description>Read-only open/closed sensor channel.</description>
+    <state readOnly="true"/>
+  </channel-type>
+
   <!-- quantities -->
   <channel-type id="current">
     <item-type>Number:ElectricCurrent</item-type>

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -181,9 +181,9 @@
         <label>Pause</label>
         <description>Pause/resume charging without ending the transaction. Send ON to apply a 0 A limit (SetChargingProfile), OFF to restore the last non-zero limit. OCPP 1.6 has no dedicated pause command.</description>
       </channel>
-      <channel id="cableConnected" typeId="switch">
+      <channel id="cableConnected" typeId="contact">
         <label>Cable Connected</label>
-        <description>Read-only. ON while an EV is plugged in (connector status Preparing/Charging/SuspendedEV/SuspendedEVSE/Finishing), OFF otherwise. Derived from StatusNotification since OCPP 1.6 has no dedicated plug-presence message.</description>
+        <description>Read-only. CLOSED while an EV is plugged in (connector status Preparing/Charging/SuspendedEV/SuspendedEVSE/Finishing), OPEN otherwise. Derived from StatusNotification since OCPP 1.6 has no dedicated plug-presence message.</description>
       </channel>
       <channel id="timestampStart" typeId="dateTime">
         <label>Start timestamp</label>

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -181,6 +181,10 @@
         <label>Pause</label>
         <description>Pause/resume charging without ending the transaction. Send ON to apply a 0 A limit (SetChargingProfile), OFF to restore the last non-zero limit. OCPP 1.6 has no dedicated pause command.</description>
       </channel>
+      <channel id="cableConnected" typeId="switch">
+        <label>Cable Connected</label>
+        <description>Read-only. ON while an EV is plugged in (connector status Preparing/Charging/SuspendedEV/SuspendedEVSE/Finishing), OFF otherwise. Derived from StatusNotification since OCPP 1.6 has no dedicated plug-presence message.</description>
+      </channel>
       <channel id="timestampStart" typeId="dateTime">
         <label>Start timestamp</label>
         <description>Start timestamp of most recent transaction.</description>


### PR DESCRIPTION
OCPP 1.6 has no plug-presence message — automation that needs to know whether an EV is plugged in has to interpret the raw `chargePointStatus` string itself. New read-only `cableConnected` Switch channel derives it: ON for Preparing/Charging/SuspendedEV/SuspendedEVSE/Finishing, OFF for Available/Unavailable/Faulted/Reserved. Updated on every StatusNotification.

Verified against Wallbox Copper SB / Pulsar Plus (FW 6.7.38) and Phoenix Contact CHARX SEC-3xxx (FW 1.9.0): plug → ON at Preparing, unplug → OFF at Available.
