### PR TITLE
[ocpp] Add hardwareMaxCurrent channel backed by a vendor config key

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/OcppBindingConstants.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/OcppBindingConstants.java
@@ -53,6 +53,7 @@ public interface OcppBindingConstants extends BaseBindingConstants {
   ChannelRef RESET = new ChannelRef("reset");
   ChannelRef LOCK = new ChannelRef("lock");
   ChannelRef PAUSE = new ChannelRef("pause");
+  ChannelRef HARDWARE_MAX_CURRENT = new ChannelRef("hardwareMaxCurrent");
   ChannelRef ENERGY_ACTIVE_EXPORT = new ChannelRef("energyActiveExport");
   ChannelRef ENERGY_ACTIVE_IMPORT = new ChannelRef("energyActiveImport");
   ChannelRef ENERGY_REACTIVE_EXPORT = new ChannelRef("energyReactiveExport");

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ConnectorConfig.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ConnectorConfig.java
@@ -24,4 +24,5 @@ public class ConnectorConfig implements Configuration {
   public Integer connectorId;
   public String remoteStartTag = DEFAULT_REMOTE_START_TAG;
   public Integer profileMinIntervalMs;
+  public String hardwareMaxCurrentKey;
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -1,8 +1,12 @@
 package org.connectorio.addons.binding.ocpp.internal.handler;
 
 import eu.chargetime.ocpp.model.core.AuthorizationStatus;
+import eu.chargetime.ocpp.model.core.ChangeConfigurationRequest;
 import eu.chargetime.ocpp.model.core.ChargePointStatus;
+import eu.chargetime.ocpp.model.core.GetConfigurationConfirmation;
+import eu.chargetime.ocpp.model.core.GetConfigurationRequest;
 import eu.chargetime.ocpp.model.core.IdTagInfo;
+import eu.chargetime.ocpp.model.core.KeyValueType;
 import eu.chargetime.ocpp.model.core.MeterValue;
 import eu.chargetime.ocpp.model.core.MeterValuesConfirmation;
 import eu.chargetime.ocpp.model.core.MeterValuesRequest;
@@ -44,6 +48,7 @@ import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerCallback;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,6 +72,7 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
   private Integer currentTransactionId;
   private String remoteStartTag;
   private Integer connectorId;
+  private String hardwareMaxCurrentKey;
 
   private final ChargeLimitCommandHandler chargeLimitHandler;
   private final ChargingCommandHandler chargingHandler;
@@ -134,6 +140,7 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
         remoteStartTag = ConnectorConfig.DEFAULT_REMOTE_START_TAG;
       }
       connectorId = config.get().connectorId;
+      hardwareMaxCurrentKey = config.get().hardwareMaxCurrentKey;
     } else {
       remoteStartTag = ConnectorConfig.DEFAULT_REMOTE_START_TAG;
     }
@@ -162,6 +169,14 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
         } else {
           chargeLimitHandler.resume(this);
         }
+      }
+    } else if (OcppBindingConstants.HARDWARE_MAX_CURRENT.getAsString().equals(channelId)) {
+      if (command instanceof RefreshType) {
+        readHardwareMaxCurrent();
+      } else if (command instanceof DecimalType) {
+        writeHardwareMaxCurrent(((DecimalType) command).intValue());
+      } else if (command instanceof QuantityType) {
+        writeHardwareMaxCurrent(((QuantityType<?>) command).intValue());
       }
     }
   }
@@ -195,6 +210,59 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
       }
       getCallback().stateUpdated(
           new ChannelUID(getThing().getUID(), OcppBindingConstants.LOCK.getAsString()), OnOffType.OFF);
+    });
+  }
+
+  private void writeHardwareMaxCurrent(int amps) {
+    if (ocppSender == null || chargerSerialNumber == null) {
+      return;
+    }
+    if (hardwareMaxCurrentKey == null || hardwareMaxCurrentKey.trim().isEmpty()) {
+      logger.warn("hardwareMaxCurrentKey not configured on {}; cannot write hardware max current",
+          getThing().getUID());
+      return;
+    }
+    ChargerReference reference = new ChargerReference(chargerSerialNumber);
+    ocppSender.send(reference, new ChangeConfigurationRequest(hardwareMaxCurrentKey, Integer.toString(amps)))
+        .whenComplete((confirmation, ex) -> {
+          if (ex != null) {
+            logger.warn("ChangeConfiguration[{}={}] for {} failed: {}", hardwareMaxCurrentKey, amps,
+                getThing().getUID(), ex.getMessage());
+          } else {
+            logger.debug("ChangeConfiguration[{}={}] for {}: {}", hardwareMaxCurrentKey, amps,
+                getThing().getUID(), confirmation);
+          }
+        });
+  }
+
+  private void readHardwareMaxCurrent() {
+    if (ocppSender == null || chargerSerialNumber == null
+        || hardwareMaxCurrentKey == null || hardwareMaxCurrentKey.trim().isEmpty()) {
+      return;
+    }
+    ChargerReference reference = new ChargerReference(chargerSerialNumber);
+    GetConfigurationRequest request = new GetConfigurationRequest();
+    request.setKey(new String[]{ hardwareMaxCurrentKey });
+    ocppSender.<GetConfigurationConfirmation>send(reference, request).whenComplete((confirmation, ex) -> {
+      if (ex != null || confirmation == null || confirmation.getConfigurationKey() == null) {
+        if (ex != null) {
+          logger.warn("GetConfiguration[{}] for {} failed: {}", hardwareMaxCurrentKey, getThing().getUID(),
+              ex.getMessage());
+        }
+        return;
+      }
+      for (KeyValueType kv : confirmation.getConfigurationKey()) {
+        if (hardwareMaxCurrentKey.equals(kv.getKey()) && kv.getValue() != null) {
+          try {
+            double amps = Double.parseDouble(kv.getValue().trim());
+            getCallback().stateUpdated(
+                new ChannelUID(getThing().getUID(), OcppBindingConstants.HARDWARE_MAX_CURRENT.getAsString()),
+                new QuantityType<>(amps, Units.AMPERE));
+          } catch (NumberFormatException e) {
+            logger.debug("Could not parse {}={} as a current value", hardwareMaxCurrentKey, kv.getValue());
+          }
+        }
+      }
     });
   }
 

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -192,6 +192,10 @@
         <label>Pause</label>
         <description>Pause/resume charging without ending the transaction. Send ON to apply a 0 A limit (SetChargingProfile), OFF to restore the last non-zero limit. OCPP 1.6 has no dedicated pause command.</description>
       </channel>
+      <channel id="hardwareMaxCurrent" typeId="current">
+        <label>Hardware Max Current</label>
+        <description>Read/write the charger's persisted hardware current ceiling via a vendor-specific configuration key (set hardwareMaxCurrentKey on the connector; e.g. Wallbox uses chargingALimitConn1). Commands are written with ChangeConfiguration; REFRESH reads back with GetConfiguration. Inactive if no key is configured.</description>
+      </channel>
       <channel id="timestampStart" typeId="dateTime">
         <label>Start timestamp</label>
         <description>Start timestamp of most recent transaction.</description>
@@ -350,6 +354,11 @@
         </description>
         <default>500</default>
         <unitLabel>ms</unitLabel>
+        <advanced>true</advanced>
+      </parameter>
+      <parameter name="hardwareMaxCurrentKey" type="text" required="false">
+        <label>Hardware Max Current Key</label>
+        <description>Vendor-specific OCPP configuration key backing the hardwareMaxCurrent channel (read with GetConfiguration, written with ChangeConfiguration). Wallbox uses chargingALimitConn1. Leave empty to disable the channel.</description>
         <advanced>true</advanced>
       </parameter>
     </config-description>


### PR DESCRIPTION
Chargers persist a hardware current ceiling in a vendor-specific OCPP configuration key (Wallbox uses `chargingALimitConn1`). New `hardwareMaxCurrent` Number:ElectricCurrent channel exposes it: commands are written with `ChangeConfiguration`, `REFRESH` reads back with `GetConfiguration`. The key is set per connector via the new `hardwareMaxCurrentKey` config; the channel is inactive until a key is configured, so chargers without such a key are unaffected.

Stacks on #142. Verified against Wallbox Copper SB / Pulsar Plus (FW 6.7.38) with `chargingALimitConn1`.
