### PR TITLE
[ocpp] Register the server smart-charging profile

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppServer.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/OcppServer.java
@@ -17,7 +17,7 @@
  */
 package org.connectorio.addons.binding.ocpp.internal.server;
 
-import eu.chargetime.ocpp.feature.profile.ClientSmartChargingProfile;
+import eu.chargetime.ocpp.feature.profile.ServerSmartChargingProfile;
 import eu.chargetime.ocpp.feature.profile.ServerRemoteTriggerProfile;
 import eu.chargetime.ocpp.feature.profile.ServerCoreEventHandler;
 import eu.chargetime.ocpp.JSONConfiguration;
@@ -80,8 +80,10 @@ public class OcppServer implements OcppSender {
       this.server = new JSONServer(new ServerCoreProfile(handler));
     }
 
-    ServerSmartChargingHandler smartHandler = new ServerSmartChargingHandler();
-    this.server.addFeatureProfile(new ClientSmartChargingProfile(smartHandler));
+    // Register the SERVER smart-charging profile so the CSMS can SEND SetChargingProfile /
+    // ClearChargingProfile / GetCompositeSchedule. (Previously the *client* profile was registered,
+    // which is the charge-point side and does not let the server issue smart-charging CALLs.)
+    this.server.addFeatureProfile(new ServerSmartChargingProfile());
     this.server.addFeatureProfile(new ServerRemoteTriggerProfile());
   }
 


### PR DESCRIPTION
The server registered `ClientSmartChargingProfile` — the charge-point side — so the CSMS could never issue SetChargingProfile, ClearChargingProfile or GetCompositeSchedule; the CALLs silently went nowhere. Registering `ServerSmartChargingProfile` lets the server actually send them. Found while driving a Wallbox and a Phoenix CHARX from the binding: SetChargingProfile only started reaching the charger after this swap.
