### PR TITLE
[ocpp] ACK charger-level MeterValues and StatusNotification

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerConnectorAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerConnectorAdapter.java
@@ -40,12 +40,22 @@ public class ChargerConnectorAdapter implements StatusNotificationHandler, Meter
   @Override
   public StatusNotificationConfirmation handleStatusNotification(StatusNotificationRequest request) {
     listener.onRequest(request);
+    if (!handlers.containsKey(request.getConnectorId())) {
+      // Charger-level (connectorId 0) or a connector with no Thing — ACK so the OCPP layer does
+      // not answer the charge point with NotSupported.
+      return new StatusNotificationConfirmation();
+    }
     return handle(handler -> handler.handleStatusNotification(request), request.getConnectorId());
   }
 
   @Override
   public MeterValuesConfirmation handleMeterValues(MeterValuesRequest request) {
     listener.onRequest(request);
+    if (!handlers.containsKey(request.getConnectorId())) {
+      // Charger-level (connectorId 0, e.g. idle clock-aligned MeterValues) or a connector with no
+      // Thing — ACK with an empty confirmation rather than letting the library reply NotSupported.
+      return new MeterValuesConfirmation();
+    }
     return handle(handler -> handler.handleMeterValues(request), request.getConnectorId());
   }
 

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerConnectorAdapterTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerConnectorAdapterTest.java
@@ -1,0 +1,58 @@
+package org.connectorio.addons.binding.ocpp.internal.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.core.MeterValuesConfirmation;
+import eu.chargetime.ocpp.model.core.MeterValuesRequest;
+import eu.chargetime.ocpp.model.core.StatusNotificationConfirmation;
+import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
+import org.connectorio.addons.binding.ocpp.internal.OcppRequestListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ChargerConnectorAdapterTest {
+
+  private ConnectorThingHandler connector1;
+  private ChargerConnectorAdapter adapter;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    OcppRequestListener<Request> listener = mock(OcppRequestListener.class);
+    connector1 = mock(ConnectorThingHandler.class);
+    adapter = new ChargerConnectorAdapter(listener);
+  }
+
+  @Test
+  void chargerLevelMeterValuesIsAckedNotNull() {
+    // connectorId 0 (charger-level, e.g. idle clock-aligned MeterValues) has no connector Thing.
+    adapter.addConnector(1, connector1);
+    MeterValuesRequest request = mock(MeterValuesRequest.class);
+    when(request.getConnectorId()).thenReturn(0);
+
+    MeterValuesConfirmation conf = adapter.handleMeterValues(request);
+
+    // must ACK (non-null) so the OCPP layer does not answer the charge point NotSupported
+    assertThat(conf).isNotNull();
+    verify(connector1, never()).handleMeterValues(any(MeterValuesRequest.class));
+  }
+
+  @Test
+  void chargerLevelStatusNotificationIsAckedNotNull() {
+    // connectorId 0 (whole-charger status) likewise has no connector Thing.
+    adapter.addConnector(1, connector1);
+    StatusNotificationRequest request = mock(StatusNotificationRequest.class);
+    when(request.getConnectorId()).thenReturn(0);
+
+    StatusNotificationConfirmation conf = adapter.handleStatusNotification(request);
+
+    assertThat(conf).isNotNull();
+    verify(connector1, never()).handleStatusNotification(any(StatusNotificationRequest.class));
+  }
+}


### PR DESCRIPTION
`ChargerConnectorAdapter` returned null whenever a request's connectorId had no registered connector Thing — which includes connectorId 0, used for charger-level StatusNotification and for idle clock-aligned MeterValues. chargetime/ocpp then answers the charge point with NotSupported on every such message, spamming errors and dropping the data. ACK with an empty confirmation instead. Seen continuously against a Phoenix CHARX that sends connectorId-0 MeterValues every cycle.
