### PR TITLE
[ocpp] Ignore RefreshType in the command handlers

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandler.java
@@ -12,6 +12,7 @@ import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +23,10 @@ public class ChargeLimitCommandHandler {
     private double lastRequestedLimit = -1;
 
     public void handle(Command command, ConnectorCommandContext context) {
+        if (command instanceof RefreshType) {
+            // chargeLimit is a write-only control; REFRESH (e.g. on item link) has nothing to read.
+            return;
+        }
         double limit;
         if (command instanceof DecimalType) {
             limit = ((DecimalType) command).doubleValue();

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargingCommandHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargingCommandHandler.java
@@ -6,6 +6,7 @@ import org.connectorio.addons.binding.ocpp.internal.OcppSender;
 import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,6 +14,10 @@ public class ChargingCommandHandler {
     private final Logger logger = LoggerFactory.getLogger(ChargingCommandHandler.class);
 
     public void handle(Command command, ConnectorCommandContext context) {
+        if (command instanceof RefreshType) {
+            // charging is a write-only RemoteStart/Stop control; REFRESH has nothing to read.
+            return;
+        }
         if (!(command instanceof OnOffType)) {
             logger.warn("Unsupported command type for charging control: {}", command.getClass());
             return;

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandlerTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandlerTest.java
@@ -109,4 +109,12 @@ class ChargeLimitCommandHandlerTest {
     // then
     verify(sender, never()).send(any(ChargerReference.class), any(Request.class));
   }
+
+  @Test
+  void shouldIgnoreRefreshType() {
+    // chargeLimit is a write-only control; REFRESH must be a no-op
+    handler.handle(org.openhab.core.types.RefreshType.REFRESH, context);
+
+    verify(sender, never()).send(any(ChargerReference.class), any(Request.class));
+  }
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargingCommandHandlerTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargingCommandHandlerTest.java
@@ -105,4 +105,12 @@ class ChargingCommandHandlerTest {
     // then
     verify(sender, never()).send(any(ChargerReference.class), any(Request.class));
   }
+
+  @Test
+  void shouldIgnoreRefreshType() {
+    // charging is a write-only RemoteStart/Stop control; REFRESH must be a no-op
+    handler.handle(org.openhab.core.types.RefreshType.REFRESH, context);
+
+    verify(sender, never()).send(any(ChargerReference.class), any(Request.class));
+  }
 }


### PR DESCRIPTION
The chargeLimit and charging channels are write-only (SetChargingProfile / RemoteStart-Stop). openHAB issues a REFRESH when an item is linked, which both handlers logged as "Unsupported command type". Ignore RefreshType so linking an item no longer produces a spurious warning.
