### PR TITLE
[ocpp] Apply charge limits to the running transaction with TxProfile

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandler.java
@@ -97,9 +97,22 @@ public class ChargeLimitCommandHandler {
         ChargingProfile profile = new ChargingProfile();
         profile.setChargingProfileId(1);
         profile.setStackLevel(0);
-        profile.setChargingProfilePurpose(ChargingProfilePurposeType.TxDefaultProfile);
         profile.setChargingProfileKind(ChargingProfileKindType.Relative);
         profile.setChargingSchedule(schedule);
+
+        // A limit applied while a transaction is running must target that transaction with a
+        // TxProfile carrying its transactionId. Per OCPP 1.6 Smart Charging a TxDefaultProfile
+        // sets the default for *future* transactions, so spec-strict charge points may defer a
+        // mid-session TxDefaultProfile to the next transaction instead of acting on the running
+        // one. Fall back to TxDefaultProfile only when no transaction is active, which seeds the
+        // limit for the next session.
+        Integer transactionId = context.getCurrentTransactionId();
+        if (transactionId != null) {
+            profile.setChargingProfilePurpose(ChargingProfilePurposeType.TxProfile);
+            profile.setTransactionId(transactionId);
+        } else {
+            profile.setChargingProfilePurpose(ChargingProfilePurposeType.TxDefaultProfile);
+        }
 
         SetChargingProfileRequest setProfileRequest = new SetChargingProfileRequest(context.getConnectorId(), profile);
 

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandlerTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargeLimitCommandHandlerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import eu.chargetime.ocpp.model.Request;
 import eu.chargetime.ocpp.model.core.ChargingProfile;
+import eu.chargetime.ocpp.model.core.ChargingProfilePurposeType;
 import eu.chargetime.ocpp.model.smartcharging.SetChargingProfileRequest;
 import java.util.concurrent.CompletableFuture;
 import org.connectorio.addons.binding.ocpp.internal.OcppSender;
@@ -102,6 +103,48 @@ class ChargeLimitCommandHandlerTest {
 
     // then
     verify(sender, never()).send(any(ChargerReference.class), any(Request.class));
+  }
+
+  @Test
+  void shouldUseTxProfileWithTransactionIdWhenTransactionActive() {
+    // given a running transaction
+    when(context.getOcppSender()).thenReturn(sender);
+    when(context.getChargerSerialNumber()).thenReturn("charger-serial");
+    when(context.getCurrentTransactionId()).thenReturn(42);
+    when(sender.send(any(ChargerReference.class), any(Request.class)))
+      .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    handler.handle(new DecimalType(16), context);
+
+    // then the profile targets the running transaction
+    ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+    verify(sender).send(any(ChargerReference.class), requestCaptor.capture());
+
+    ChargingProfile profile = ((SetChargingProfileRequest) requestCaptor.getValue()).getCsChargingProfiles();
+    assertThat(profile.getChargingProfilePurpose()).isEqualTo(ChargingProfilePurposeType.TxProfile);
+    assertThat(profile.getTransactionId()).isEqualTo(42);
+  }
+
+  @Test
+  void shouldUseTxDefaultProfileWhenNoTransaction() {
+    // given no active transaction
+    when(context.getOcppSender()).thenReturn(sender);
+    when(context.getChargerSerialNumber()).thenReturn("charger-serial");
+    when(context.getCurrentTransactionId()).thenReturn(null);
+    when(sender.send(any(ChargerReference.class), any(Request.class)))
+      .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    handler.handle(new DecimalType(16), context);
+
+    // then it seeds the next session's default and carries no transaction id
+    ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+    verify(sender).send(any(ChargerReference.class), requestCaptor.capture());
+
+    ChargingProfile profile = ((SetChargingProfileRequest) requestCaptor.getValue()).getCsChargingProfiles();
+    assertThat(profile.getChargingProfilePurpose()).isEqualTo(ChargingProfilePurposeType.TxDefaultProfile);
+    assertThat(profile.getTransactionId()).isNull();
   }
 
   @Test


### PR DESCRIPTION
A mid-session limit change was always sent as a TxDefaultProfile, which a charger applies to the next transaction rather than the one in progress — so a new current didn't take effect until the car was replugged. When a transaction is active, send the limit as a TxProfile carrying that transactionId (falling back to TxDefaultProfile only when idle) so it takes effect on the current session, as OCPP 1.6 Smart Charging intends.
