### PR TITLE
[ocpp] Keep transaction ids unique across a charge point's connectors

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerConnectorAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerConnectorAdapter.java
@@ -12,6 +12,7 @@ import eu.chargetime.ocpp.model.core.StopTransactionRequest;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.connectorio.addons.binding.ocpp.internal.OcppRequestListener;
 import org.connectorio.addons.binding.ocpp.internal.server.listener.MeterValuesHandler;
@@ -26,6 +27,9 @@ public class ChargerConnectorAdapter implements StatusNotificationHandler, Meter
   private final Logger logger = LoggerFactory.getLogger(ChargerConnectorAdapter.class);
   private final Map<Integer, ConnectorThingHandler> handlers = new ConcurrentHashMap<>();
   private final Map<Integer, Integer> transactionMap = new ConcurrentHashMap<>();
+  // Charger-wide transaction-id sequence shared with every connector so their ids never collide;
+  // StopTransaction carries no connectorId, so the id is the only key back to the right connector.
+  private final AtomicInteger transactionSequence = new AtomicInteger(1);
   private final OcppRequestListener<Request> listener;
 
   public ChargerConnectorAdapter(OcppRequestListener<Request> listener) {
@@ -33,6 +37,7 @@ public class ChargerConnectorAdapter implements StatusNotificationHandler, Meter
   }
 
   public void addConnector(int connector, ConnectorThingHandler handler) {
+    handler.setTransactionSequence(transactionSequence);
     handlers.put(connector, handler);
   }
 
@@ -80,6 +85,7 @@ public class ChargerConnectorAdapter implements StatusNotificationHandler, Meter
     for (Entry<Integer, Integer> entry : transactionMap.entrySet()) {
       if (entry.getValue().equals(request.getTransactionId())) {
         connectorId = entry.getKey();
+        break;
       }
     }
 

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandler.java
@@ -59,7 +59,10 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
 
   private static final long DEFAULT_PROFILE_MIN_INTERVAL_MS = 500L;
 
-  private final AtomicInteger transactionId = new AtomicInteger();
+  // Transaction-id sequence. Replaced with a charger-wide shared sequence (see setTransactionSequence)
+  // so connectors on the same charge point never issue colliding ids — StopTransaction carries only a
+  // transactionId, no connectorId, so colliding ids cannot be routed back to the right connector.
+  private AtomicInteger transactionId = new AtomicInteger(1);
   private final Logger logger = LoggerFactory.getLogger(ConnectorThingHandler.class);
 
   private OcppSender ocppSender;
@@ -84,6 +87,14 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
   protected void setOcppSender(OcppSender sender, String chargerSerial) {
     this.ocppSender = sender;
     this.chargerSerialNumber = chargerSerial;
+  }
+
+  /**
+   * Share one transaction-id sequence across all connectors of a charge point so the ids stay unique
+   * per charger. Called by {@link ChargerConnectorAdapter} when the connector is registered.
+   */
+  void setTransactionSequence(AtomicInteger sequence) {
+    this.transactionId = sequence;
   }
 
   @Override
@@ -260,6 +271,9 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
   public StartTransactionConfirmation handleStartTransaction(StartTransactionRequest request) {
     String tag = request.getIdTag();
 
+    int txId = generateId();
+    currentTransactionId = txId;
+
     ThingHandlerCallback callback = getCallback();
     callback.stateUpdated(new ChannelUID(getThing().getUID(), "idTag"), new StringType(tag));
     callback.stateUpdated(new ChannelUID(getThing().getUID(), OcppBindingConstants.CHARGING.getAsString()), OnOffType.ON);
@@ -267,7 +281,7 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
     callback.stateUpdated(new ChannelUID(getThing().getUID(), "meterStart"), new QuantityType<>(request.getMeterStart(), Units.WATT_HOUR));
 
     IdTagInfo tagInfo = new IdTagInfo(AuthorizationStatus.Accepted);
-    return new StartTransactionConfirmation(tagInfo, generateId());
+    return new StartTransactionConfirmation(tagInfo, txId);
   }
 
   @Override
@@ -275,7 +289,9 @@ public class ConnectorThingHandler extends GenericThingHandlerBase<ServerBridgeH
     String tag = request.getIdTag();
 
     Integer txId = request.getTransactionId();
-    if (transactionId.get() != txId + 1) {
+    // Only act on a stop for this connector's own running transaction; with one charge point exposing
+    // several connectors a StopTransaction can be dispatched here for another connector's id.
+    if (currentTransactionId == null || !currentTransactionId.equals(txId)) {
       return new StopTransactionConfirmation();
     }
 

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerConnectorAdapterTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerConnectorAdapterTest.java
@@ -8,24 +8,38 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.core.AuthorizationStatus;
+import eu.chargetime.ocpp.model.core.IdTagInfo;
 import eu.chargetime.ocpp.model.core.MeterValuesConfirmation;
 import eu.chargetime.ocpp.model.core.MeterValuesRequest;
+import eu.chargetime.ocpp.model.core.StartTransactionConfirmation;
+import eu.chargetime.ocpp.model.core.StartTransactionRequest;
 import eu.chargetime.ocpp.model.core.StatusNotificationConfirmation;
 import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
+import eu.chargetime.ocpp.model.core.StopTransactionRequest;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.connectorio.addons.binding.ocpp.internal.OcppRequestListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class ChargerConnectorAdapterTest {
 
+  @Mock
+  private OcppRequestListener<Request> listener;
+  @Mock
   private ConnectorThingHandler connector1;
+  @Mock
+  private ConnectorThingHandler connector2;
+
   private ChargerConnectorAdapter adapter;
 
   @BeforeEach
-  @SuppressWarnings("unchecked")
   void setUp() {
-    OcppRequestListener<Request> listener = mock(OcppRequestListener.class);
-    connector1 = mock(ConnectorThingHandler.class);
     adapter = new ChargerConnectorAdapter(listener);
   }
 
@@ -54,5 +68,56 @@ class ChargerConnectorAdapterTest {
 
     assertThat(conf).isNotNull();
     verify(connector1, never()).handleStatusNotification(any(StatusNotificationRequest.class));
+  }
+
+  @Test
+  void connectorsOfTheSameChargerShareOneTransactionSequence() {
+    // when both connectors of one charge point are registered
+    adapter.addConnector(1, connector1);
+    adapter.addConnector(2, connector2);
+
+    // then they are handed the SAME sequence instance, so their generated ids never collide
+    ArgumentCaptor<AtomicInteger> seq1 = ArgumentCaptor.forClass(AtomicInteger.class);
+    ArgumentCaptor<AtomicInteger> seq2 = ArgumentCaptor.forClass(AtomicInteger.class);
+    verify(connector1).setTransactionSequence(seq1.capture());
+    verify(connector2).setTransactionSequence(seq2.capture());
+    assertThat(seq1.getValue()).isSameAs(seq2.getValue());
+  }
+
+  @Test
+  void stopTransactionIsRoutedToTheConnectorThatStartedThatTransaction() {
+    adapter.addConnector(1, connector1);
+    adapter.addConnector(2, connector2);
+
+    // connector 1 starts transaction id 1, connector 2 starts transaction id 2
+    StartTransactionRequest start1 = startOn(1);
+    StartTransactionRequest start2 = startOn(2);
+    when(connector1.handleStartTransaction(start1)).thenReturn(confirmation(1));
+    when(connector2.handleStartTransaction(start2)).thenReturn(confirmation(2));
+    adapter.handleStartTransaction(start1);
+    adapter.handleStartTransaction(start2);
+
+    // a stop for transaction id 2 must reach connector 2 only
+    StopTransactionRequest stop = mockStop(2);
+    adapter.handleStopTransaction(stop);
+
+    verify(connector2).handleStopTransaction(stop);
+    verify(connector1, never()).handleStopTransaction(any(StopTransactionRequest.class));
+  }
+
+  private StartTransactionRequest startOn(int connectorId) {
+    StartTransactionRequest request = mock(StartTransactionRequest.class);
+    when(request.getConnectorId()).thenReturn(connectorId);
+    return request;
+  }
+
+  private StartTransactionConfirmation confirmation(int transactionId) {
+    return new StartTransactionConfirmation(new IdTagInfo(AuthorizationStatus.Accepted), transactionId);
+  }
+
+  private StopTransactionRequest mockStop(int transactionId) {
+    StopTransactionRequest request = mock(StopTransactionRequest.class);
+    when(request.getTransactionId()).thenReturn(transactionId);
+    return request;
   }
 }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandlerTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ConnectorThingHandlerTest.java
@@ -1,6 +1,7 @@
 package org.connectorio.addons.binding.ocpp.internal.handler;
 
 import eu.chargetime.ocpp.model.core.ChargePointStatus;
+import eu.chargetime.ocpp.model.core.StartTransactionRequest;
 import eu.chargetime.ocpp.model.core.StatusNotificationRequest;
 import eu.chargetime.ocpp.model.core.StopTransactionRequest;
 import java.time.ZonedDateTime;
@@ -34,10 +35,12 @@ class ConnectorThingHandlerTest {
 
     @Test
     void testResetOnStopTransaction() {
-        StopTransactionRequest request = new StopTransactionRequest(0, ZonedDateTime.now(), 1);
+        // Stops are matched against the connector's own running transaction, so own one first.
+        StartTransactionRequest start = new StartTransactionRequest(1, "testTag", 0, ZonedDateTime.now());
+        int txId = handler.handleStartTransaction(start).getTransactionId();
+
+        StopTransactionRequest request = new StopTransactionRequest(0, ZonedDateTime.now(), txId);
         request.setIdTag("testTag");
-        // Simulate transactionId state
-        handler.setTransactionId(2); // so transactionId.get() == 2, request.getTransactionId() == 1
         handler.handleStopTransaction(request);
         verifyResetChannels();
     }


### PR DESCRIPTION
Each connector minted its own transaction ids from a per-connector counter, so the two connectors of a multi-connector charge point (e.g. a Phoenix CHARX) produced colliding ids. StopTransaction carries only the transaction id, so a stop could be routed to the wrong connector. Share one transaction sequence per charge point and match a StopTransaction against the connector's own current transaction id.
