### PR TITLE
[ocpp] Treat NONE/blank Ocular eco mode as disabled

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ServerConfig.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/config/ServerConfig.java
@@ -19,13 +19,14 @@ package org.connectorio.addons.binding.ocpp.internal.config;
 
 import java.util.List;
 import org.connectorio.addons.binding.config.Configuration;
+import org.connectorio.addons.binding.ocpp.internal.server.custom.OcularSolarEcoMode.EcoMode;
 
 public class ServerConfig implements Configuration {
 
   public String address;
   public int port;
   public int heartbeat;
-  public String initialOcularEcoMode;
+  public EcoMode initialOcularEcoMode = EcoMode.NONE;
   public int pingInterval = 60;
 
   public List<String> chargers;

--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/custom/OcularSolarEcoMode.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/server/custom/OcularSolarEcoMode.java
@@ -8,50 +8,46 @@ import org.slf4j.LoggerFactory;
 import eu.chargetime.ocpp.model.core.ChangeConfigurationRequest;
 
 public class OcularSolarEcoMode {
-	private static final String KEY_ECO_MODE = "EcoMode";
-	
-	private final Logger logger = LoggerFactory.getLogger(OcularSolarEcoMode.class);
-	private final String initialOcularEcoMode;
-	private OcppSender ocppSender;
 
-  public OcularSolarEcoMode(String initialOcularEcoMode) {
+  private static final String KEY_ECO_MODE = "EcoMode";
+
+  private final Logger logger = LoggerFactory.getLogger(OcularSolarEcoMode.class);
+  private final EcoMode initialOcularEcoMode;
+  private OcppSender ocppSender;
+
+  public OcularSolarEcoMode(EcoMode initialOcularEcoMode) {
     this.initialOcularEcoMode = initialOcularEcoMode;
   }
-  
+
   public void setOcppSender(OcppSender ocppSender) {
-  	this.ocppSender = ocppSender;
+    this.ocppSender = ocppSender;
   }
 
   public enum EcoMode {
-  	FAST("0"),
-  	SOLAR_ASSIST("1"),
-  	SOLAR_ONLY("2");
-  	
-  	String value;
-  	EcoMode(String value) {
-  		this.value = value;
-  	}
+    NONE(""),
+    FAST("0"),
+    SOLAR_ASSIST("1"),
+    SOLAR_ONLY("2");
+
+    final String value;
+
+    EcoMode(String value) {
+      this.value = value;
+    }
   }
 
   public void applyOcularEcoMode(ChargerReference reference) {
-  	if (ocppSender == null) {
+    if (ocppSender == null) {
       logger.warn("OcppSender or charger serial not set. Cannot send charging profile.");
-  		return;
-  	}
-  	
-  	if (initialOcularEcoMode == null) {
-  		return;
-  	}  	
-  	EcoMode ecoMode;
-    try {
-       ecoMode = EcoMode.valueOf(initialOcularEcoMode);
-    } catch (IllegalArgumentException e) {
-    	logger.warn("Cannot set ecoMode as it is the unknown value %s.", initialOcularEcoMode);
-    	return;
+      return;
     }
-  	
+    if (initialOcularEcoMode == EcoMode.NONE) {
+      // The feature is disabled (the configured default) — nothing to push.
+      return;
+    }
+
     try {
-      ChangeConfigurationRequest request = new ChangeConfigurationRequest(KEY_ECO_MODE, ecoMode.value);
+      ChangeConfigurationRequest request = new ChangeConfigurationRequest(KEY_ECO_MODE, initialOcularEcoMode.value);
       ocppSender.send(reference, request).whenComplete((confirmation, ex) -> {
         if (ex != null) {
           logger.warn("ChangeConfiguration failed", ex);

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/custom/OcularSolarEcoModeTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/server/custom/OcularSolarEcoModeTest.java
@@ -1,0 +1,40 @@
+package org.connectorio.addons.binding.ocpp.internal.server.custom;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import eu.chargetime.ocpp.model.Confirmation;
+import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.core.ChangeConfigurationRequest;
+import java.util.concurrent.CompletableFuture;
+import org.connectorio.addons.binding.ocpp.internal.OcppSender;
+import org.connectorio.addons.binding.ocpp.internal.server.ChargerReference;
+import org.junit.jupiter.api.Test;
+
+class OcularSolarEcoModeTest {
+
+  private final OcppSender sender = mock(OcppSender.class);
+  private final ChargerReference charger = new ChargerReference("cp");
+
+  @Test
+  void doesNotSendWhenDisabled() {
+    // NONE is the configured default — the feature is off, nothing should be pushed.
+    OcularSolarEcoMode eco = new OcularSolarEcoMode(OcularSolarEcoMode.EcoMode.NONE);
+    eco.setOcppSender(sender);
+    eco.applyOcularEcoMode(charger);
+    verify(sender, never()).send(any(ChargerReference.class), any(Request.class));
+  }
+
+  @Test
+  void sendsChangeConfigurationForValidMode() {
+    when(sender.send(any(ChargerReference.class), any(Request.class)))
+        .thenReturn(CompletableFuture.<Confirmation>completedFuture(null));
+    OcularSolarEcoMode eco = new OcularSolarEcoMode(OcularSolarEcoMode.EcoMode.SOLAR_ONLY);
+    eco.setOcppSender(sender);
+    eco.applyOcularEcoMode(charger);
+    verify(sender).send(any(ChargerReference.class), any(ChangeConfigurationRequest.class));
+  }
+}


### PR DESCRIPTION
`initialOcularEcoMode` defaults to `NONE` (also the "Disabled" option in thing-types.xml), but the `EcoMode` enum only has FAST/SOLAR_ASSIST/SOLAR_ONLY — no `NONE`. So `EcoMode.valueOf("NONE")` throws on every charger connect and logs `Cannot set ecoMode as it is the unknown value %s.` once per charger, for anyone on the default config. This treats `NONE`/blank as disabled (skip silently) and fixes the log placeholder (`%s` → `{}`) so a genuinely unknown value actually prints.
