### PR TITLE
Update plc4x-extras to 0.13.0-connectorio-3.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -37,7 +37,7 @@
     <compiler.source>21</compiler.source>
     <compiler.target>21</compiler.target>
 
-    <plc4x-extras.version>0.12.0</plc4x-extras.version>
+    <plc4x-extras.version>0.13.0-connectorio-3</plc4x-extras.version>
     <bacnet4j-wrapper.version>1.3.0-beta1</bacnet4j-wrapper.version>
 
     <openhab.version>5.0.0</openhab.version>


### PR DESCRIPTION
This should fix some of OSGi resolver issues observed with earlier release affecting 3.1.x branch.