### PR TITLE
[ocpp] ACK StopTransaction instead of replying NotSupported

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerConnectorAdapter.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargerConnectorAdapter.java
@@ -17,10 +17,13 @@ import org.connectorio.addons.binding.ocpp.internal.OcppRequestListener;
 import org.connectorio.addons.binding.ocpp.internal.server.listener.MeterValuesHandler;
 import org.connectorio.addons.binding.ocpp.internal.server.listener.StatusNotificationHandler;
 import org.connectorio.addons.binding.ocpp.internal.server.listener.TransactionHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ChargerConnectorAdapter implements StatusNotificationHandler, MeterValuesHandler,
   TransactionHandler {
 
+  private final Logger logger = LoggerFactory.getLogger(ChargerConnectorAdapter.class);
   private final Map<Integer, ConnectorThingHandler> handlers = new ConcurrentHashMap<>();
   private final Map<Integer, Integer> transactionMap = new ConcurrentHashMap<>();
   private final OcppRequestListener<Request> listener;
@@ -73,8 +76,16 @@ public class ChargerConnectorAdapter implements StatusNotificationHandler, Meter
     if (connectorId != null) {
       return handle(handler -> handler.handleStopTransaction(request), connectorId);
     }
-    // unknown transaction
-    return null;
+    // Unknown transaction — no StartTransaction was tracked for this id. Common with free-charging
+    // (FreeMode): the charger runs a local transaction and sends StopTransaction at session end without
+    // a StartTransaction we ever saw. OCPP requires the CSMS to ACK StopTransaction regardless; reply
+    // with an empty confirmation instead of returning null, which makes the library send a NotSupported
+    // CallError — leaving the charger retrying or holding a dangling transaction (which can then block
+    // the next StartTransaction).
+    logger.info("StopTransaction for transaction {} has no matching StartTransaction; acknowledging it"
+        + " without a per-connector state change (charger likely runs a local/free transaction).",
+        request.getTransactionId());
+    return new StopTransactionConfirmation();
   }
 
   private <C> C handle(Function<ConnectorThingHandler, C> handler, int connector) {


### PR DESCRIPTION
A charger running a free/local transaction — e.g. a Wallbox in free-charging mode — sends StopTransaction at the end of a session for a transaction the server never started. `handleStopTransaction` can't map that transactionId to a connector and returns `null`, so the library answers with a `NotSupported` CallError on every charge-end. OCPP expects the CSMS to always acknowledge StopTransaction; without it the charger may retry or keep the transaction open, which can block the next StartTransaction. Reply with an empty `StopTransactionConfirmation` when the transaction is unknown.
