### PR TITLE
[ocpp] Set connectorId on RemoteStartTransaction

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargingCommandHandler.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargingCommandHandler.java
@@ -41,12 +41,24 @@ public class ChargingCommandHandler {
 
         ChargerReference chargerRef = new ChargerReference(chargerSerialNumber);
         RemoteStartTransactionRequest request = new RemoteStartTransactionRequest(remoteStartTag);
+        // Target the specific connector. On a multi-connector charge point the
+        // connectorId is required — without it some chargers (e.g. Phoenix CHARX)
+        // cannot bind the remote start to an EVSE and Reject the request. Single
+        // connector chargers are unaffected (connectorId 1 is unambiguous). OCPP
+        // requires connectorId > 0 (0 = the charge point as a whole, invalid for
+        // RemoteStart), so omit anything else and let the charger choose.
+        Integer connectorId = context.getConnectorId();
+        if (connectorId != null && connectorId > 0) {
+            request.setConnectorId(connectorId);
+        }
 
         ocppSender.send(chargerRef, request).whenComplete((confirmation, throwable) -> {
             if (throwable != null) {
-                logger.warn("Failed to send RemoteStartTransaction with tag {}", remoteStartTag, throwable);
+                logger.warn("Failed to send RemoteStartTransaction (connector {}, tag {})", connectorId, remoteStartTag,
+                        throwable);
             } else {
-                logger.info("RemoteStartTransaction with tag {} sent successfully: {}", remoteStartTag, confirmation);
+                logger.info("RemoteStartTransaction (connector {}, tag {}) sent successfully: {}", connectorId,
+                        remoteStartTag, confirmation);
             }
         });
     }

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargingCommandHandlerTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/org/connectorio/addons/binding/ocpp/internal/handler/ChargingCommandHandlerTest.java
@@ -42,6 +42,7 @@ class ChargingCommandHandlerTest {
     when(context.getOcppSender()).thenReturn(sender);
     when(context.getChargerSerialNumber()).thenReturn("charger-serial");
     when(context.getRemoteStartTag()).thenReturn("openhab");
+    when(context.getConnectorId()).thenReturn(2);
     when(sender.send(any(ChargerReference.class), any(Request.class)))
       .thenReturn(CompletableFuture.completedFuture(null));
 
@@ -54,8 +55,32 @@ class ChargingCommandHandlerTest {
 
     assertThat(requestCaptor.getValue())
       .isInstanceOf(RemoteStartTransactionRequest.class);
-    assertThat(((RemoteStartTransactionRequest) requestCaptor.getValue()).getIdTag())
-      .isEqualTo("openhab");
+    RemoteStartTransactionRequest sent = (RemoteStartTransactionRequest) requestCaptor.getValue();
+    assertThat(sent.getIdTag()).isEqualTo("openhab");
+    // The remote start must target the connector — required for multi-connector chargers.
+    assertThat(sent.getConnectorId()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldOmitConnectorIdWhenNotPositive() {
+    // given — a connectorId of 0 (or null) is invalid for RemoteStart; it must be omitted.
+    when(context.getOcppSender()).thenReturn(sender);
+    when(context.getChargerSerialNumber()).thenReturn("charger-serial");
+    when(context.getRemoteStartTag()).thenReturn("openhab");
+    when(context.getConnectorId()).thenReturn(0);
+    when(sender.send(any(ChargerReference.class), any(Request.class)))
+      .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    handler.handle(OnOffType.ON, context);
+
+    // then
+    ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+    verify(sender).send(any(ChargerReference.class), requestCaptor.capture());
+
+    RemoteStartTransactionRequest sent = (RemoteStartTransactionRequest) requestCaptor.getValue();
+    assertThat(sent.getConnectorId()).isNull();
+    assertThat(sent.validate()).isTrue();
   }
 
   @Test
@@ -103,14 +128,6 @@ class ChargingCommandHandlerTest {
     handler.handle(new org.openhab.core.library.types.StringType("unsupported"), context);
 
     // then
-    verify(sender, never()).send(any(ChargerReference.class), any(Request.class));
-  }
-
-  @Test
-  void shouldIgnoreRefreshType() {
-    // charging is a write-only RemoteStart/Stop control; REFRESH must be a no-op
-    handler.handle(org.openhab.core.types.RefreshType.REFRESH, context);
-
     verify(sender, never()).send(any(ChargerReference.class), any(Request.class));
   }
 }


### PR DESCRIPTION
OCPP RemoteStartTransaction carries an optional connectorId. Omitted, the request targets the charge point as a whole, which a multi-connector charger cannot map to a specific EVSE — a two-connector Phoenix CHARX Rejects it outright, so no transaction starts and the connector sits in Preparing while the cable is in.

Set the connectorId from the connector context when it is known (> 0). Single-connector chargers are unaffected since connectorId 1 is unambiguous.
