### PR TITLE
[ocpp] Tolerate meter-less StopTransaction requests

### DIFF
--- a/bundles/org.connectorio.addons.binding.ocpp/src/main/java/eu/chargetime/ocpp/model/core/StopTransactionRequest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/main/java/eu/chargetime/ocpp/model/core/StopTransactionRequest.java
@@ -1,0 +1,168 @@
+/*
+ * ChargeTime.eu - Java-OCA-OCPP
+ *
+ * MIT License
+ *
+ * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package eu.chargetime.ocpp.model.core;
+
+import eu.chargetime.ocpp.model.Request;
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+/**
+ * Sent by the Charge Point to the Central System — end of a transaction.
+ *
+ * <p>LOCAL OVERRIDE of the class embedded in {@code eu.chargetime.ocpp:v1_6} (this bundle's own
+ * classes precede the embedded jar on the Bundle-ClassPath). The upstream {@link #validate()}
+ * requires {@code meterStop}, {@code timestamp} and {@code transactionId} to all be present and
+ * every {@code transactionData} entry to validate. A meter-less charge point running a local
+ * (FreeMode) transaction — Phoenix Contact CHARX with no energy meter — can legitimately omit
+ * {@code meterStop} or the transaction id, and pads {@code transactionData} with placeholder
+ * samples. Upstream validation then makes the library answer with a CallError
+ * (OccurenceConstraintViolation) instead of a StopTransaction confirmation; the charge point
+ * retries, gives up (TransactionMessageAttempts) and keeps the transaction open — leaving a
+ * phantom transaction that wedges the connector. OCPP 1.6 requires the CSMS to acknowledge
+ * StopTransaction regardless, so this override only insists on a {@code timestamp} and leaves
+ * interpretation of the remaining fields to the handler (which tolerates unknown/absent
+ * transaction ids already).
+ */
+public class StopTransactionRequest implements Request {
+
+  private String idTag;
+  private Integer meterStop;
+  private ZonedDateTime timestamp;
+  private Integer transactionId;
+  private Reason reason;
+  private MeterValue[] transactionData;
+
+  public StopTransactionRequest() {}
+
+  public StopTransactionRequest(Integer meterStop, ZonedDateTime timestamp, Integer transactionId) {
+    this.meterStop = meterStop;
+    this.timestamp = timestamp;
+    this.transactionId = transactionId;
+  }
+
+  @Override
+  public boolean validate() {
+    // Tolerant on purpose — see the class javadoc. A stop without meterStop/transactionId is
+    // still a stop the CSMS must confirm; rejecting it strands the transaction on the charger.
+    return timestamp != null;
+  }
+
+  public String getIdTag() {
+    return idTag;
+  }
+
+  public void setIdTag(String idTag) {
+    this.idTag = idTag;
+  }
+
+  public Integer getMeterStop() {
+    return meterStop;
+  }
+
+  public void setMeterStop(Integer meterStop) {
+    this.meterStop = meterStop;
+  }
+
+  public ZonedDateTime getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(ZonedDateTime timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public ZonedDateTime objTimestamp() {
+    return timestamp;
+  }
+
+  public Integer getTransactionId() {
+    return transactionId;
+  }
+
+  public void setTransactionId(Integer transactionId) {
+    this.transactionId = transactionId;
+  }
+
+  public Reason getReason() {
+    return reason;
+  }
+
+  public void setReason(Reason reason) {
+    this.reason = reason;
+  }
+
+  public Reason objReason() {
+    return reason;
+  }
+
+  public MeterValue[] getTransactionData() {
+    return transactionData;
+  }
+
+  public void setTransactionData(MeterValue[] transactionData) {
+    this.transactionData = transactionData;
+  }
+
+  @Override
+  public boolean transactionRelated() {
+    return true;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    StopTransactionRequest that = (StopTransactionRequest) o;
+    return Objects.equals(idTag, that.idTag)
+        && Objects.equals(meterStop, that.meterStop)
+        && Objects.equals(timestamp, that.timestamp)
+        && Objects.equals(transactionId, that.transactionId)
+        && reason == that.reason
+        && Objects.deepEquals(transactionData, that.transactionData);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(idTag, meterStop, timestamp, transactionId, reason, transactionData);
+  }
+
+  @Override
+  public String toString() {
+    return "StopTransactionRequest{"
+        + "idTag='" + idTag + '\''
+        + ", meterStop=" + meterStop
+        + ", timestamp=" + timestamp
+        + ", transactionId=" + transactionId
+        + ", reason=" + reason
+        + ", transactionData=" + (transactionData == null ? "null" : transactionData.length + " entries")
+        + '}';
+  }
+}

--- a/bundles/org.connectorio.addons.binding.ocpp/src/test/java/eu/chargetime/ocpp/model/core/StopTransactionRequestToleranceTest.java
+++ b/bundles/org.connectorio.addons.binding.ocpp/src/test/java/eu/chargetime/ocpp/model/core/StopTransactionRequestToleranceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022-2022 ConnectorIO Sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package eu.chargetime.ocpp.model.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The local override of StopTransactionRequest must ACCEPT the payloads a meter-less/FreeMode
+ * charge point (Phoenix CHARX without an energy meter) actually sends — upstream validation
+ * rejects them with OccurenceConstraintViolation, the charger retries then gives up, and the
+ * never-confirmed transaction wedges the connector (phantom transaction).
+ */
+class StopTransactionRequestToleranceTest {
+
+  @Test
+  void acceptsAStopWithoutMeterStop() {
+    StopTransactionRequest request = new StopTransactionRequest();
+    request.setTimestamp(ZonedDateTime.now());
+    request.setTransactionId(3);
+    // no meterStop — a charge point with no energy meter has nothing to report
+    assertThat(request.validate()).isTrue();
+  }
+
+  @Test
+  void acceptsAStopWithoutTransactionId() {
+    StopTransactionRequest request = new StopTransactionRequest();
+    request.setTimestamp(ZonedDateTime.now());
+    request.setMeterStop(0);
+    // no transactionId — a locally started (FreeMode) session has no CSMS-assigned id; the
+    // handler already answers unknown transactions with an empty confirmation
+    assertThat(request.validate()).isTrue();
+  }
+
+  @Test
+  void acceptsTheRegularWellFormedStop() {
+    StopTransactionRequest request = new StopTransactionRequest(0, ZonedDateTime.now(), 1);
+    request.setIdTag("openhab");
+    request.setReason(Reason.PowerLoss);
+    assertThat(request.validate()).isTrue();
+  }
+
+  @Test
+  void stillRejectsAStopWithoutTimestamp() {
+    StopTransactionRequest request = new StopTransactionRequest();
+    request.setMeterStop(0);
+    request.setTransactionId(1);
+    assertThat(request.validate()).isFalse();
+  }
+
+  @Test
+  void remainsTransactionRelated() {
+    assertThat(new StopTransactionRequest().transactionRelated()).isTrue();
+  }
+}


### PR DESCRIPTION
A meter-less/FreeMode charge point (Phoenix Contact CHARX, no internal energy meter) can legitimately omit meterStop or transactionId from StopTransaction. The embedded library's StopTransactionRequest.validate() requires both plus timestamp, so the reply is a CallError instead of a confirmation — the charge point retries, gives up, and the transaction never closes, leaving the connector holding a phantom transaction.

Different layer than the merged "acknowledge StopTransaction for unknown transactions" fix, which runs after validate() passes, for a valid-shaped stop with an unrecognized id — this fixes validate() itself, which runs first and never lets a malformed-shaped stop reach that code.

OCPP 1.6 requires the CSMS to acknowledge StopTransaction regardless of its contents, so the override only requires a timestamp — implemented as a local class that shadows the embedded library one (our sources precede it on the Bundle-ClassPath), since validate() isn't something a handler can intercept.
